### PR TITLE
Hilt를 모듈 구성 / 카카오 서치 api 적용

### DIFF
--- a/.github/workflow/labeler.yml
+++ b/.github/workflow/labeler.yml
@@ -1,0 +1,14 @@
+name: "Pull Request Labeler"
+on:
+  pull_request_target:
+    branches:
+      - develop
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/labeler@v2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,8 @@ import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    kotlin("kapt")
+    id("dagger.hilt.android.plugin")
 }
 
 android {
@@ -47,6 +49,10 @@ dependencies {
     implementation(project(":domain"))
     implementation(project(":presentation"))
     implementation(project(":data"))
+
+    kapt(Kapt.APP_LIBRARIES)
+    implementation(Libraries.APP_LIBRARIES)
+    annotationProcessor(AnnotationProcessors.APP_LIBRARIES)
 }
 
 fun getApiKey(propertyKey: String): String {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application
+        android:name="com.lighthouse.BeepApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -20,6 +21,6 @@
 
         <meta-data
             android:name="com.naver.maps.map.CLIENT_ID"
-            android:value="${naver_map_api_id}"/>
+            android:value="${naver_map_api_id}" />
     </application>
 </manifest>

--- a/app/src/main/java/com/lighthouse/BeepApplication.kt
+++ b/app/src/main/java/com/lighthouse/BeepApplication.kt
@@ -1,0 +1,11 @@
+package com.lighthouse
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class BeepApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+    }
+}

--- a/app/src/main/java/com/lighthouse/di/DataModule.kt
+++ b/app/src/main/java/com/lighthouse/di/DataModule.kt
@@ -1,0 +1,28 @@
+package com.lighthouse.di
+
+import com.lighthouse.datasource.BrandRemoteSource
+import com.lighthouse.datasource.BrandRemoteSourceImpl
+import com.lighthouse.domain.repository.BrandRepository
+import com.lighthouse.repository.BrandRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class DataModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindBrandRemoteDataSource(
+        source: BrandRemoteSourceImpl
+    ): BrandRemoteSource
+
+    @Binds
+    @Singleton
+    abstract fun bindBrandRepository(
+        repository: BrandRepositoryImpl
+    ): BrandRepository
+}

--- a/app/src/main/java/com/lighthouse/di/HTTPRequestInterceptor.kt
+++ b/app/src/main/java/com/lighthouse/di/HTTPRequestInterceptor.kt
@@ -1,0 +1,17 @@
+package com.lighthouse.di
+
+import com.lighthouse.beep.BuildConfig
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class HTTPRequestInterceptor : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val origin = chain.request()
+        val request = origin.newBuilder()
+            .addHeader("Content-Type", "application/json")
+            .addHeader("Authorization", "KakaoAK ${BuildConfig.kakaoSearchId}")
+            .build()
+        return chain.proceed(request)
+    }
+}

--- a/app/src/main/java/com/lighthouse/di/NetworkModule.kt
+++ b/app/src/main/java/com/lighthouse/di/NetworkModule.kt
@@ -1,0 +1,48 @@
+package com.lighthouse.di
+
+import com.lighthouse.network.NetworkApiService
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+
+    private const val KAKAO_URL = "https://dapi.kakao.com/"
+
+    private val moshi = Moshi.Builder()
+        .addLast(KotlinJsonAdapterFactory())
+        .build()
+
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(): OkHttpClient {
+        return OkHttpClient.Builder()
+            .addInterceptor(HTTPRequestInterceptor())
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
+        return Retrofit.Builder()
+            .client(okHttpClient)
+            .baseUrl(KAKAO_URL)
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideApiService(retrofit: Retrofit): NetworkApiService {
+        return retrofit.create(NetworkApiService::class.java)
+    }
+}

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -124,6 +124,13 @@ object Libraries {
         PAGING_COMMON_KTX,
         ROOM_COMMON
     )
+    val APP_LIBRARIES = arrayListOf(
+        HILT,
+        RETROFIT,
+        MOSHI_KOTLIN,
+        MOSHI_ADAPTERS,
+        CONVERTER_MOSHI
+    )
 }
 
 object TestImpl {
@@ -173,6 +180,12 @@ object Kapt {
     )
 
     val DATA_LIBRARIES = arrayListOf(
+        ROOM_COMPILER,
+        MOSHI_KOTLIN_CODEGEN
+    )
+
+    val APP_LIBRARIES = arrayListOf(
+        HILT,
         ROOM_COMPILER,
         MOSHI_KOTLIN_CODEGEN
     )

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -167,6 +167,10 @@ object AnnotationProcessors {
     val DATA_LIBRARIES = arrayListOf(
         ROOM_COMPILER
     )
+
+    val APP_LIBRARIES = arrayListOf(
+        ROOM_COMPILER
+    )
 }
 
 object Kapt {

--- a/data/src/main/java/com/lighthouse/datasource/BrandRemoteSource.kt
+++ b/data/src/main/java/com/lighthouse/datasource/BrandRemoteSource.kt
@@ -1,0 +1,7 @@
+package com.lighthouse.datasource
+
+import com.lighthouse.model.BrandPlaceInfoDataContainer
+
+interface BrandRemoteSource {
+    suspend fun getBrandPlaceInfo(brandName: String, x: String, y: String, rect: String, size: Int): Result<BrandPlaceInfoDataContainer>
+}

--- a/data/src/main/java/com/lighthouse/datasource/BrandRemoteSourceImpl.kt
+++ b/data/src/main/java/com/lighthouse/datasource/BrandRemoteSourceImpl.kt
@@ -1,0 +1,28 @@
+package com.lighthouse.datasource
+
+import com.lighthouse.model.BrandPlaceInfoDataContainer
+import com.lighthouse.model.CustomErrorData
+import com.lighthouse.network.NetworkApiService
+import java.net.UnknownHostException
+import javax.inject.Inject
+
+class BrandRemoteSourceImpl @Inject constructor(
+    private val networkApiService: NetworkApiService
+) : BrandRemoteSource {
+
+    override suspend fun getBrandPlaceInfo(
+        brandName: String,
+        x: String,
+        y: String,
+        rect: String,
+        size: Int
+    ): Result<BrandPlaceInfoDataContainer> {
+        val result = runCatching { networkApiService.getAllBrandPlaceInfo(brandName, x, y, rect, size) }
+
+        return when (val exception = result.exceptionOrNull()) {
+            null -> result
+            is UnknownHostException -> Result.failure(CustomErrorData.NetworkFailure)
+            else -> Result.failure(exception)
+        }
+    }
+}

--- a/data/src/main/java/com/lighthouse/mapper/BrandPlaceInfoDataContainerMapper.kt
+++ b/data/src/main/java/com/lighthouse/mapper/BrandPlaceInfoDataContainerMapper.kt
@@ -1,0 +1,18 @@
+package com.lighthouse.mapper
+
+import com.lighthouse.domain.model.BrandPlaceInfo
+import com.lighthouse.model.BrandPlaceInfoDataContainer
+
+fun BrandPlaceInfoDataContainer.toDomain(): List<BrandPlaceInfo> {
+    val brandName = this.meta.sameName.keyword
+    return this.documents.map {
+        BrandPlaceInfo(
+            addressName = it.addressName,
+            placeName = it.placeName,
+            placeUrl = it.placeUrl,
+            brand = brandName,
+            x = it.x,
+            y = it.y
+        )
+    }
+}

--- a/data/src/main/java/com/lighthouse/mapper/ErrorMapper.kt
+++ b/data/src/main/java/com/lighthouse/mapper/ErrorMapper.kt
@@ -1,0 +1,8 @@
+package com.lighthouse.mapper
+
+import com.lighthouse.domain.model.CustomError
+import com.lighthouse.model.CustomErrorData
+
+internal fun CustomErrorData.toDomain(): CustomError = when (this) {
+    is CustomErrorData.NetworkFailure -> CustomError.NetworkFailure
+}

--- a/data/src/main/java/com/lighthouse/model/BrandPlaceInfoDataContainer.kt
+++ b/data/src/main/java/com/lighthouse/model/BrandPlaceInfoDataContainer.kt
@@ -1,0 +1,41 @@
+package com.lighthouse.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class BrandPlaceInfoDataContainer(
+    val documents: List<BrandPlaceInfoData>,
+    val meta: Meta
+) {
+    @JsonClass(generateAdapter = true)
+    data class BrandPlaceInfoData(
+        @field:Json(name = "address_name") val addressName: String,
+        @field:Json(name = "category_group_code") val categoryGroupCode: String,
+        @field:Json(name = "category_group_name") val categoryGroupName: String,
+        @field:Json(name = "category_name") val categoryName: String,
+        @field:Json(name = "distance") val distance: String,
+        @field:Json(name = "id") val id: String,
+        @field:Json(name = "phone") val phone: String,
+        @field:Json(name = "place_name") val placeName: String,
+        @field:Json(name = "place_url") val placeUrl: String,
+        @field:Json(name = "road_address_name") val roadAddressName: String,
+        @field:Json(name = "x") val x: String,
+        @field:Json(name = "y") val y: String
+    )
+
+    @JsonClass(generateAdapter = true)
+    data class Meta(
+        @field:Json(name = "is_end") val isEnd: Boolean,
+        @field:Json(name = "pageable_count") val pageableCount: Int,
+        @field:Json(name = "same_name") val sameName: SameName,
+        @field:Json(name = "total_count") val totalCount: Int
+    )
+
+    @JsonClass(generateAdapter = true)
+    data class SameName(
+        @field:Json(name = "keyword") val keyword: String,
+        @field:Json(name = "region") val region: List<Any>,
+        @field:Json(name = "selected_region") val selectedRegion: String
+    )
+}

--- a/data/src/main/java/com/lighthouse/model/CustomErrorData.kt
+++ b/data/src/main/java/com/lighthouse/model/CustomErrorData.kt
@@ -1,0 +1,9 @@
+package com.lighthouse.model
+
+sealed class CustomErrorData(
+    override val message: String? = null,
+    override val cause: Throwable? = null
+) : Exception(message, cause) {
+
+    object NetworkFailure : CustomErrorData()
+}

--- a/data/src/main/java/com/lighthouse/network/NetworkApiService.kt
+++ b/data/src/main/java/com/lighthouse/network/NetworkApiService.kt
@@ -1,0 +1,17 @@
+package com.lighthouse.network
+
+import com.lighthouse.model.BrandPlaceInfoDataContainer
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface NetworkApiService {
+
+    @GET("v2/local/search/keyword.json")
+    suspend fun getAllBrandPlaceInfo(
+        @Query("query") query: String,
+        @Query("x") x: String,
+        @Query("y") y: String,
+        @Query("rect") rect: String,
+        @Query("radius") radius: Int
+    ): BrandPlaceInfoDataContainer
+}

--- a/data/src/main/java/com/lighthouse/repository/BrandRepositoryImpl.kt
+++ b/data/src/main/java/com/lighthouse/repository/BrandRepositoryImpl.kt
@@ -1,0 +1,30 @@
+package com.lighthouse.repository
+
+import com.lighthouse.datasource.BrandRemoteSource
+import com.lighthouse.domain.model.BrandPlaceInfo
+import com.lighthouse.domain.repository.BrandRepository
+import com.lighthouse.mapper.toDomain
+import com.lighthouse.model.CustomErrorData
+import javax.inject.Inject
+
+class BrandRepositoryImpl @Inject constructor(
+    private val remoteBrandSource: BrandRemoteSource
+) : BrandRepository {
+
+    override suspend fun getBrandPlaceInfo(
+        brandName: String,
+        x: String,
+        y: String,
+        rect: String,
+        size: Int
+    ): Result<List<BrandPlaceInfo>> {
+        val result = remoteBrandSource.getBrandPlaceInfo(brandName, x, y, rect, size).mapCatching { it.toDomain() }
+        val exception = result.exceptionOrNull()
+
+        return if (exception is CustomErrorData) {
+            Result.failure(exception.toDomain())
+        } else {
+            result
+        }
+    }
+}

--- a/domain/src/main/java/com/lighthouse/domain/model/CustomError.kt
+++ b/domain/src/main/java/com/lighthouse/domain/model/CustomError.kt
@@ -1,0 +1,9 @@
+package com.lighthouse.domain.model
+
+sealed class CustomError(
+    override val message: String? = null,
+    override val cause: Throwable? = null
+) : Exception(message, cause) {
+
+    object NetworkFailure : CustomError()
+}

--- a/domain/src/main/java/com/lighthouse/domain/repository/BrandRepository.kt
+++ b/domain/src/main/java/com/lighthouse/domain/repository/BrandRepository.kt
@@ -1,0 +1,7 @@
+package com.lighthouse.domain.repository
+
+import com.lighthouse.domain.model.BrandPlaceInfo
+
+interface BrandRepository {
+    suspend fun getBrandPlaceInfo(brandName: String, x: String, y: String, rect: String, size: Int): Result<List<BrandPlaceInfo>>
+}

--- a/domain/src/main/java/com/lighthouse/domain/usecase/GetBrandPlaceInfosUseCase.kt
+++ b/domain/src/main/java/com/lighthouse/domain/usecase/GetBrandPlaceInfosUseCase.kt
@@ -1,10 +1,20 @@
 package com.lighthouse.domain.usecase
 
 import com.lighthouse.domain.model.BrandPlaceInfo
+import com.lighthouse.domain.repository.BrandRepository
+import javax.inject.Inject
 
-class GetBrandPlaceInfosUseCase {
+class GetBrandPlaceInfosUseCase @Inject constructor(
+    private val brandRepository: BrandRepository
+) {
 
-    operator fun invoke(brandName: String, x: Int, y: Int, rect: Int, size: Int): List<BrandPlaceInfo> {
-        return emptyList()
+    suspend operator fun invoke(
+        brandName: String,
+        x: String,
+        y: String,
+        rect: String,
+        size: Int
+    ): Result<List<BrandPlaceInfo>> {
+        return brandRepository.getBrandPlaceInfo(brandName, x, y, rect, size)
     }
 }

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -22,5 +22,9 @@
         <activity android:name=".ui.cropgifticon.CropGifticonActivity" />
 
         <activity android:name=".ui.gallery.GalleryActivity" />
+
+        <activity
+            android:name=".ui.map.MapActivity"
+            android:exported="true" />
     </application>
 </manifest>

--- a/presentation/src/main/java/com/lighthouse/presentation/mapper/BrandPlaceInfoUiModelMapper.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/mapper/BrandPlaceInfoUiModelMapper.kt
@@ -1,0 +1,13 @@
+package com.lighthouse.presentation.mapper
+
+import com.lighthouse.domain.model.BrandPlaceInfo
+import com.lighthouse.presentation.model.BrandPlaceInfoUiModel
+
+fun BrandPlaceInfo.toPresentation(): BrandPlaceInfoUiModel = BrandPlaceInfoUiModel(
+    addressName = this.addressName,
+    placeName = this.placeName,
+    placeUrl = this.placeUrl,
+    brand = this.brand,
+    x = this.x,
+    y = this.y
+)

--- a/presentation/src/main/java/com/lighthouse/presentation/model/BrandPlaceInfoUiModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/model/BrandPlaceInfoUiModel.kt
@@ -1,0 +1,10 @@
+package com.lighthouse.presentation.model
+
+data class BrandPlaceInfoUiModel(
+    val addressName: String,
+    val placeName: String,
+    val placeUrl: String,
+    val brand: String,
+    val x: String,
+    val y: String
+)

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/map/MapActivity.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/map/MapActivity.kt
@@ -6,7 +6,9 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import com.lighthouse.presentation.R
 import com.lighthouse.presentation.databinding.ActivityMapBinding
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MapActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityMapBinding
@@ -15,5 +17,6 @@ class MapActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = DataBindingUtil.setContentView(this, R.layout.activity_map)
+        viewModel // by ViewModels는 lazy라서 실행 확인을 위한 코드
     }
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/map/MapViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/map/MapViewModel.kt
@@ -1,5 +1,37 @@
 package com.lighthouse.presentation.ui.map
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.lighthouse.domain.usecase.GetBrandPlaceInfosUseCase
+import com.lighthouse.presentation.mapper.toPresentation
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class MapViewModel : ViewModel()
+@HiltViewModel
+class MapViewModel @Inject constructor(
+    private val getBrandPlaceInfosUseCase: GetBrandPlaceInfosUseCase
+) : ViewModel() {
+
+    // TODO 임시 데이터 변경 필요
+    private val brandList = arrayListOf<String>().apply {
+        add("스타벅스")
+        add("베스킨라빈스")
+        add("BHC")
+        add("BBQ")
+    }
+
+    init {
+        viewModelScope.launch {
+            for (query in brandList) {
+                getBrandPlaceInfosUseCase(query, "37.2840", "127.1071", "500", 5)
+                    .onSuccess { brandPlaceInfos ->
+                        val brandPlaceInfoUiModels = brandPlaceInfos.map { it.toPresentation() }
+                        Log.d("TAG", "브랜드 리스트 갖고 오기 성공 -> $brandPlaceInfoUiModels")
+                    }
+                    .onFailure { Log.d("TAG", " 브랜드 리스트 갖고 오기 실패 -> $it") }
+            }
+        }
+    }
+}


### PR DESCRIPTION
resolved: #24   
resolved: #14

## 작업 내용

- App 레이어에 Hilt 모듈 클래스 작성
- 카카오 서치 api UseCase, Repository, DataSource Hilt 활용해서 구현

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정

## 동작 화면

<img width="1050" alt="image" src="https://user-images.githubusercontent.com/53300830/201170887-ae1644b2-a1f9-4a12-8ef7-769701fc4ce2.png">

![제목 없는 다이어그램-페이지-1 drawio (1)](https://user-images.githubusercontent.com/53300830/201174939-a084bffa-c279-4a4e-97cf-b806cc516d07.png)


