### PR TITLE
SignIn 레이아웃 작업

### DIFF
--- a/presentation/src/main/java/com/lighthouse/presentation/ui/signin/SignInFragment.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/signin/SignInFragment.kt
@@ -9,7 +9,6 @@ import android.view.ViewGroup
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
@@ -25,7 +24,6 @@ import com.lighthouse.presentation.ui.common.viewBindings
 class SignInFragment : Fragment() {
 
     private val binding by viewBindings(FragmentSignInBinding::bind)
-    private val viewModel: SignInViewModel by viewModels()
 
     private lateinit var googleSignInClient: GoogleSignInClient
     private val activityLauncher: ActivityResultLauncher<Intent> =

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/signin/SignInFragment.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/signin/SignInFragment.kt
@@ -14,18 +14,21 @@ import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.common.api.ApiException
 import com.google.android.material.snackbar.Snackbar
+import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.GoogleAuthProvider
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 import com.lighthouse.presentation.R
 import com.lighthouse.presentation.databinding.FragmentSignInBinding
 import com.lighthouse.presentation.ui.common.viewBindings
+import com.lighthouse.presentation.ui.main.MainActivity
 
 class SignInFragment : Fragment() {
 
     private val binding by viewBindings(FragmentSignInBinding::bind)
 
     private lateinit var googleSignInClient: GoogleSignInClient
+    private val auth: FirebaseAuth = Firebase.auth
     private val activityLauncher: ActivityResultLauncher<Intent> =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == Activity.RESULT_OK) {
@@ -48,7 +51,7 @@ class SignInFragment : Fragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        initGoogleLogin()
+        auth.currentUser?.let { gotoMain() } ?: initGoogleLogin()
     }
 
     private fun initGoogleLogin() {
@@ -66,12 +69,18 @@ class SignInFragment : Fragment() {
 
     private fun signInWithGoogle(idToken: String) {
         val credential = GoogleAuthProvider.getCredential(idToken, null)
-        Firebase.auth.signInWithCredential(credential).addOnCompleteListener { task ->
+        auth.signInWithCredential(credential).addOnCompleteListener { task ->
             if (task.isSuccessful) {
                 Snackbar.make(requireView(), getString(R.string.signin_success), Snackbar.LENGTH_SHORT).show()
+                gotoMain()
             } else {
                 Snackbar.make(requireView(), getString(R.string.signin_fail), Snackbar.LENGTH_SHORT).show()
             }
         }
+    }
+
+    private fun gotoMain() {
+        val intent = Intent(requireContext(), MainActivity::class.java)
+        startActivity(intent)
     }
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/signin/SignInFragment.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/signin/SignInFragment.kt
@@ -1,14 +1,17 @@
 package com.lighthouse.presentation.ui.signin
 
 import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.common.api.ApiException
 import com.google.android.material.snackbar.Snackbar
@@ -24,19 +27,9 @@ class SignInFragment : Fragment() {
     private val binding by viewBindings(FragmentSignInBinding::bind)
     private val viewModel: SignInViewModel by viewModels()
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.fragment_sign_in, container, false)
-    }
-
-    private fun initGoogleLogin() {
-        val googleSignInOptions = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-            .requestEmail()
-            .requestIdToken(getString(R.string.default_web_client_id))
-            .build()
-
-        val googleSignInClient = GoogleSignIn.getClient(requireContext(), googleSignInOptions)
-
-        val activityLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+    private lateinit var googleSignInClient: GoogleSignInClient
+    private val activityLauncher: ActivityResultLauncher<Intent> =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == Activity.RESULT_OK) {
                 val task = GoogleSignIn.getSignedInAccountFromIntent(result.data)
 
@@ -52,7 +45,25 @@ class SignInFragment : Fragment() {
             }
         }
 
-        activityLauncher.launch(googleSignInClient.signInIntent)
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.fragment_sign_in, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        initGoogleLogin()
+    }
+
+    private fun initGoogleLogin() {
+        val googleSignInOptions = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+            .requestEmail()
+            .requestIdToken(getString(R.string.default_web_client_id))
+            .build()
+
+        googleSignInClient = GoogleSignIn.getClient(requireContext(), googleSignInOptions)
+
+        binding.btnGoogleLogin.setOnClickListener {
+            activityLauncher.launch(googleSignInClient.signInIntent)
+        }
     }
 
     private fun signInWithGoogle(idToken: String) {

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/signin/SignInViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/signin/SignInViewModel.kt
@@ -1,5 +1,0 @@
-package com.lighthouse.presentation.ui.signin
-
-import androidx.lifecycle.ViewModel
-
-class SignInViewModel : ViewModel()

--- a/presentation/src/main/res/layout/fragment_sign_in.xml
+++ b/presentation/src/main/res/layout/fragment_sign_in.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
@@ -12,7 +13,19 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="#E91E63"
         tools:context=".ui.signin.SignInFragment">
+
+        <com.google.android.gms.common.SignInButton
+            android:id="@+id/btn_google_login"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="60dp"
+            app:buttonSize="wide"
+            app:colorScheme="auto"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/layout/fragment_sign_in.xml
+++ b/presentation/src/main/res/layout/fragment_sign_in.xml
@@ -5,9 +5,6 @@
 
     <data>
 
-        <variable
-            name="vm"
-            type="com.lighthouse.presentation.ui.signin.SignInViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout


### PR DESCRIPTION
resolved: #18 

## 작업 내용

- SignInFragment 레이아웃 구성, 구글에서 제공하는 로그인 버튼을 갖다 썼습니다. 
- 로그인 버튼 누르면 구글 로그인 시도. 이미 로그인 되어 있는 경우에는 바로 넘어갑니다. 

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정

## 동작 화면

![Screen_Recording_20221112_180438_BEEP_1](https://user-images.githubusercontent.com/69582122/201467318-7a7b29ce-3ab7-4835-93c3-e8a88d100781.gif)
![Screen_Recording_20221112_180501_BEEP_1](https://user-images.githubusercontent.com/69582122/201467326-af409b57-e515-426c-95d0-eff7c17e7762.gif)

## 특이 사항

- auth의 로그인 토큰이 유지되고 있는지 판단 후 MainActiviy로 이동하는 것은 스플래시 화면을 만들고 그쪽으로 옮길 예정입니다.
- 에디터 상에서 구글 로그인 버튼의 아이콘이 표시되지 않을텐데, 실 기기에서 실행하면 잘 뜹니다 (40분 허비)
- 슬랙에 말씀드린대로 모니터에서 보던 primary color를 실제로 사용하니 너무 쨍해서 톤다운이 필요합니다.

---

task 나누지 말고 하나로 할 걸 그랬어요 

요정도 기능과 레이아웃 PR을 분리하는건 불필요한 정도인데 왜 task를 나눴을까요 과거의 나