### PR TITLE
카카오 검색 성공/실패 테스트 코드 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,6 +43,10 @@ android {
     buildFeatures {
         dataBinding = true
     }
+
+    packagingOptions {
+        resources.excludes.add("META-INF/LICENSE*")
+    }
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,12 @@ buildscript {
     }
 }
 
+allprojects {
+    configurations.all {
+        resolutionStrategy.force("org.objenesis:objenesis:2.6")
+    }
+}
+
 tasks.register("clean", Delete::class) {
     delete(rootProject.buildDir)
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -134,18 +134,33 @@ object Libraries {
 }
 
 object TestImpl {
-    private const val JUNIT4 = "junit:junit:${Versions.JUNIT}" // TODO 5 쓰는 쪽으로 바꿔야함
+    private const val JUNIT4 = "junit:junit:${Versions.JUNIT}"
     private const val PAGING_COMMON = "androidx.paging:paging-common:${Versions.PAGING_KTX}"
+
+    private const val JUNIT_JUPITER_PARAMS = "org.junit.jupiter:junit-jupiter-params:5.8.2"
+    private const val JUNIT_JUPITER_ENGINE = "org.junit.jupiter:junit-jupiter-engine:5.8.2"
+    private const val JUNIT_VINTAGE_ENGINE = "org.junit.vintage:junit-vintage-engine:5.8.2"
+    private const val MOCK = "io.mockk:mockk:1.12.0"
+    private const val GOOGLE_TRUTH = "com.google.truth:truth:1.1.3"
+    private const val COROUTINES_TEST = "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0"
 
     val TEST_LIBRARIES = arrayListOf(
         JUNIT4,
-        PAGING_COMMON
+        PAGING_COMMON,
+        JUNIT_JUPITER_PARAMS,
+        JUNIT_JUPITER_ENGINE,
+        JUNIT_VINTAGE_ENGINE,
+        MOCK,
+        GOOGLE_TRUTH,
+        COROUTINES_TEST
     )
 }
 
 object AndroidTestImpl {
     private const val ANDROID_JUNIT = "androidx.test.ext:junit:${Versions.ANDROID_JUNIT}"
     private const val ESPRESSO = "androidx.test.espresso:espresso-core:${Versions.ESPRESSO}"
+    private const val MOCKITO_CORE = "org.mockito:mockito-core:2.28.2"
+    private const val MOCKITO_ANDROID = "org.mockito:mockito-android:2.28.2"
 
     private const val WORK_MANAGER = "androidx.work:work-testing:${Versions.WORK_MANAGER}"
 
@@ -153,6 +168,11 @@ object AndroidTestImpl {
         ANDROID_JUNIT,
         ESPRESSO,
         WORK_MANAGER
+    )
+
+    val DATA_LIBRARIES = arrayListOf(
+        MOCKITO_CORE,
+        MOCKITO_ANDROID
     )
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -37,6 +37,10 @@ object Versions {
     const val JUNIT = "4.13.2"
     const val ANDROID_JUNIT = "1.1.3"
     const val ESPRESSO = "3.4.0"
+    const val JUNIT5 = "5.8.2"
+    const val MOCK = "1.12.0"
+    const val GOOGLE_TRUTH = "1.1.3"
+    const val COROUTINES_TEST = "1.6.0"
 }
 
 object Libraries {
@@ -137,12 +141,12 @@ object TestImpl {
     private const val JUNIT4 = "junit:junit:${Versions.JUNIT}"
     private const val PAGING_COMMON = "androidx.paging:paging-common:${Versions.PAGING_KTX}"
 
-    private const val JUNIT_JUPITER_PARAMS = "org.junit.jupiter:junit-jupiter-params:5.8.2"
-    private const val JUNIT_JUPITER_ENGINE = "org.junit.jupiter:junit-jupiter-engine:5.8.2"
-    private const val JUNIT_VINTAGE_ENGINE = "org.junit.vintage:junit-vintage-engine:5.8.2"
-    private const val MOCK = "io.mockk:mockk:1.12.0"
-    private const val GOOGLE_TRUTH = "com.google.truth:truth:1.1.3"
-    private const val COROUTINES_TEST = "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0"
+    private const val JUNIT_JUPITER_PARAMS = "org.junit.jupiter:junit-jupiter-params:${Versions.JUNIT5}"
+    private const val JUNIT_JUPITER_ENGINE = "org.junit.jupiter:junit-jupiter-engine:${Versions.JUNIT5}"
+    private const val JUNIT_VINTAGE_ENGINE = "org.junit.vintage:junit-vintage-engine:${Versions.JUNIT5}"
+    private const val MOCK = "io.mockk:mockk:${Versions.MOCK}"
+    private const val GOOGLE_TRUTH = "com.google.truth:truth:${Versions.GOOGLE_TRUTH}"
+    private const val COROUTINES_TEST = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.COROUTINES_TEST}"
 
     val TEST_LIBRARIES = arrayListOf(
         JUNIT4,

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -11,6 +11,7 @@ java {
 
 dependencies {
     implementation(Libraries.DOMAIN_LIBRARIES)
+    testImplementation(TestImpl.TEST_LIBRARIES)
 }
 kapt {
     correctErrorTypes = true

--- a/domain/src/main/java/com/lighthouse/domain/model/CustomError.kt
+++ b/domain/src/main/java/com/lighthouse/domain/model/CustomError.kt
@@ -6,4 +6,5 @@ sealed class CustomError(
 ) : Exception(message, cause) {
 
     object NetworkFailure : CustomError()
+    object NotFoundBrandPlaceInfos : CustomError()
 }

--- a/domain/src/main/java/com/lighthouse/domain/usecase/GetBrandPlaceInfosUseCase.kt
+++ b/domain/src/main/java/com/lighthouse/domain/usecase/GetBrandPlaceInfosUseCase.kt
@@ -10,13 +10,18 @@ class GetBrandPlaceInfosUseCase @Inject constructor(
 ) {
 
     suspend operator fun invoke(
-        brandName: String,
+        brandNames: List<String>,
         x: String,
         y: String,
         rect: String,
         size: Int
     ): Result<List<BrandPlaceInfo>> {
-        val brandPlaceInfos = brandRepository.getBrandPlaceInfo(brandName, x, y, rect, size).getOrThrow()
+        val brandPlaceInfos = mutableListOf<BrandPlaceInfo>()
+
+        for (brandName in brandNames) {
+            val brandSearchResults = brandRepository.getBrandPlaceInfo(brandName, x, y, rect, size).getOrThrow()
+            if (brandSearchResults.isNotEmpty()) brandPlaceInfos.addAll(brandSearchResults)
+        }
 
         return if (brandPlaceInfos.isNotEmpty()) {
             Result.success(brandPlaceInfos)

--- a/domain/src/main/java/com/lighthouse/domain/usecase/GetBrandPlaceInfosUseCase.kt
+++ b/domain/src/main/java/com/lighthouse/domain/usecase/GetBrandPlaceInfosUseCase.kt
@@ -1,6 +1,7 @@
 package com.lighthouse.domain.usecase
 
 import com.lighthouse.domain.model.BrandPlaceInfo
+import com.lighthouse.domain.model.CustomError
 import com.lighthouse.domain.repository.BrandRepository
 import javax.inject.Inject
 
@@ -15,6 +16,12 @@ class GetBrandPlaceInfosUseCase @Inject constructor(
         rect: String,
         size: Int
     ): Result<List<BrandPlaceInfo>> {
-        return brandRepository.getBrandPlaceInfo(brandName, x, y, rect, size)
+        val brandPlaceInfos = brandRepository.getBrandPlaceInfo(brandName, x, y, rect, size).getOrThrow()
+
+        return if (brandPlaceInfos.isNotEmpty()) {
+            Result.success(brandPlaceInfos)
+        } else {
+            Result.failure(CustomError.NotFoundBrandPlaceInfos)
+        }
     }
 }

--- a/domain/src/test/java/com/lighthouse/domain/usecase/GetBrandPlaceInfosUseCaseTest.kt
+++ b/domain/src/test/java/com/lighthouse/domain/usecase/GetBrandPlaceInfosUseCaseTest.kt
@@ -20,17 +20,18 @@ class GetBrandPlaceInfosUseCaseTest {
     @DisplayName("[성공] 검색 결과를 갖고온다")
     fun getBrandPlaceInfoSuccess() = runTest {
         // given
-        val brandPlaceInfo: List<BrandPlaceInfo> = listOf(BrandPlaceInfo("서울 중구", "스타벅스", "", "", "", ""))
         val useCase = GetBrandPlaceInfosUseCase(brandRepository)
-        coEvery {
-            brandRepository.getBrandPlaceInfo("스타벅스", "37.2840", "127.1071", "500", 5)
-        } returns Result.success(brandPlaceInfo)
+        for (keyword in brandKeyword) {
+            coEvery {
+                brandRepository.getBrandPlaceInfo(keyword, "37.2840", "127.1071", "500", 5)
+            } returns Result.success(brandPlaceInfo)
+        }
 
         // when
-        val action = useCase("스타벅스", "37.2840", "127.1071", "500", 5).getOrThrow()
+        val action = useCase(brandKeyword, "37.2840", "127.1071", "500", 5).getOrThrow()
 
         // then
-        Truth.assertThat(action).isEqualTo(brandPlaceInfo)
+        Truth.assertThat(action).isEqualTo(brandPlaceInfoResults)
     }
 
     @Test
@@ -38,14 +39,26 @@ class GetBrandPlaceInfosUseCaseTest {
     fun getBrandPlaceInfoNotFound() = runTest {
         // given
         val useCase = GetBrandPlaceInfosUseCase(brandRepository)
-        coEvery {
-            brandRepository.getBrandPlaceInfo("", "", "", "", 0)
-        } returns Result.success(emptyList())
+        for (keyword in brandKeyword) {
+            coEvery {
+                brandRepository.getBrandPlaceInfo(keyword, "37.2840", "127.1071", "500", 5)
+            } returns Result.success(emptyList())
+        }
 
         // when
-        val action = useCase("", "", "", "", 0).exceptionOrNull()
+        val action = useCase(brandKeyword, "37.2840", "127.1071", "500", 5).exceptionOrNull()
 
         // then
         Truth.assertThat(action).isInstanceOf(CustomError.NotFoundBrandPlaceInfos::class.java)
+    }
+
+    companion object {
+        private val brandKeyword: List<String> = listOf("스타벅스", "베스킨라빈스", "BBQ")
+        private val brandPlaceInfo: List<BrandPlaceInfo> = listOf(BrandPlaceInfo("서울 중구", "스타벅스", "", "", "", ""),)
+        private val brandPlaceInfoResults: List<BrandPlaceInfo> = listOf(
+            BrandPlaceInfo("서울 중구", "스타벅스", "", "", "", ""),
+            BrandPlaceInfo("서울 중구", "스타벅스", "", "", "", ""),
+            BrandPlaceInfo("서울 중구", "스타벅스", "", "", "", "")
+        )
     }
 }

--- a/domain/src/test/java/com/lighthouse/domain/usecase/GetBrandPlaceInfosUseCaseTest.kt
+++ b/domain/src/test/java/com/lighthouse/domain/usecase/GetBrandPlaceInfosUseCaseTest.kt
@@ -54,7 +54,7 @@ class GetBrandPlaceInfosUseCaseTest {
 
     companion object {
         private val brandKeyword: List<String> = listOf("스타벅스", "베스킨라빈스", "BBQ")
-        private val brandPlaceInfo: List<BrandPlaceInfo> = listOf(BrandPlaceInfo("서울 중구", "스타벅스", "", "", "", ""),)
+        private val brandPlaceInfo: List<BrandPlaceInfo> = listOf(BrandPlaceInfo("서울 중구", "스타벅스", "", "", "", ""))
         private val brandPlaceInfoResults: List<BrandPlaceInfo> = listOf(
             BrandPlaceInfo("서울 중구", "스타벅스", "", "", "", ""),
             BrandPlaceInfo("서울 중구", "스타벅스", "", "", "", ""),

--- a/domain/src/test/java/com/lighthouse/domain/usecase/GetBrandPlaceInfosUseCaseTest.kt
+++ b/domain/src/test/java/com/lighthouse/domain/usecase/GetBrandPlaceInfosUseCaseTest.kt
@@ -1,0 +1,51 @@
+package com.lighthouse.domain.usecase
+
+import com.google.common.truth.Truth
+import com.lighthouse.domain.model.BrandPlaceInfo
+import com.lighthouse.domain.model.CustomError
+import com.lighthouse.domain.repository.BrandRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.jupiter.api.DisplayName
+
+@ExperimentalCoroutinesApi
+class GetBrandPlaceInfosUseCaseTest {
+
+    private val brandRepository: BrandRepository = mockk()
+
+    @Test
+    @DisplayName("[성공] 검색 결과를 갖고온다")
+    fun getBrandPlaceInfoSuccess() = runTest {
+        // given
+        val brandPlaceInfo: List<BrandPlaceInfo> = listOf(BrandPlaceInfo("서울 중구", "스타벅스", "", "", "", ""))
+        val useCase = GetBrandPlaceInfosUseCase(brandRepository)
+        coEvery {
+            brandRepository.getBrandPlaceInfo("스타벅스", "37.2840", "127.1071", "500", 5)
+        } returns Result.success(brandPlaceInfo)
+
+        // when
+        val action = useCase("스타벅스", "37.2840", "127.1071", "500", 5).getOrThrow()
+
+        // then
+        Truth.assertThat(action).isEqualTo(brandPlaceInfo)
+    }
+
+    @Test
+    @DisplayName("[실패] 검색 결과가 존재하지 않는다")
+    fun getBrandPlaceInfoNotFound() = runTest {
+        // given
+        val useCase = GetBrandPlaceInfosUseCase(brandRepository)
+        coEvery {
+            brandRepository.getBrandPlaceInfo("", "", "", "", 0)
+        } returns Result.success(emptyList())
+
+        // when
+        val action = useCase("", "", "", "", 0).exceptionOrNull()
+
+        // then
+        Truth.assertThat(action).isInstanceOf(CustomError.NotFoundBrandPlaceInfos::class.java)
+    }
+}

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
@@ -15,6 +17,7 @@ android {
         targetSdk = AppConfig.targetSdk
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments["runnerBuilder"] = "de.mannodermaus.junit5.AndroidJUnit5Builder"
     }
 
     buildTypes {
@@ -32,8 +35,16 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+
     buildFeatures {
         dataBinding = true
+    }
+
+    testOptions {
+        unitTests {
+            isReturnDefaultValues = true
+            isIncludeAndroidResources = true
+        }
     }
 }
 
@@ -42,12 +53,26 @@ dependencies {
 
 //    implementation(platform(Libraries.FIREBASE_BOM))
 
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.3")
     implementation(Libraries.VIEW_LIBRARIES)
     testImplementation(TestImpl.TEST_LIBRARIES)
     kapt(Kapt.VIEW_LIBRARIES)
     androidTestImplementation(AndroidTestImpl.VIEW_LIBRARIES)
     annotationProcessor(AnnotationProcessors.VIEW_LIBRARIES)
+
 }
 kapt {
     correctErrorTypes = true
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        freeCompilerArgs = listOf("-Xjsr305=strict")
+        jvmTarget = "1.8"
+    }
+}
+
+// JUnit5
+tasks.withType<Test> {
+    useJUnitPlatform()
 }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -59,8 +59,8 @@ dependencies {
     kapt(Kapt.VIEW_LIBRARIES)
     androidTestImplementation(AndroidTestImpl.VIEW_LIBRARIES)
     annotationProcessor(AnnotationProcessors.VIEW_LIBRARIES)
-
 }
+
 kapt {
     correctErrorTypes = true
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/mapper/BrandPlaceInfoUiModelMapper.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/mapper/BrandPlaceInfoUiModelMapper.kt
@@ -3,11 +3,13 @@ package com.lighthouse.presentation.mapper
 import com.lighthouse.domain.model.BrandPlaceInfo
 import com.lighthouse.presentation.model.BrandPlaceInfoUiModel
 
-fun BrandPlaceInfo.toPresentation(): BrandPlaceInfoUiModel = BrandPlaceInfoUiModel(
-    addressName = this.addressName,
-    placeName = this.placeName,
-    placeUrl = this.placeUrl,
-    brand = this.brand,
-    x = this.x,
-    y = this.y
-)
+fun List<BrandPlaceInfo>.toPresentation(): List<BrandPlaceInfoUiModel> = map {
+    BrandPlaceInfoUiModel(
+        addressName = it.addressName,
+        placeName = it.placeName,
+        placeUrl = it.placeUrl,
+        brand = it.brand,
+        x = it.x,
+        y = it.y
+    )
+}

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/map/MapActivity.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/map/MapActivity.kt
@@ -4,9 +4,14 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.lighthouse.presentation.R
 import com.lighthouse.presentation.databinding.ActivityMapBinding
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MapActivity : AppCompatActivity() {
@@ -17,6 +22,24 @@ class MapActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = DataBindingUtil.setContentView(this, R.layout.activity_map)
-        viewModel // by ViewModels는 lazy라서 실행 확인을 위한 코드
+
+        setObserveSearchData()
+    }
+
+    private fun setObserveSearchData() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.state.collectLatest { state ->
+                    // TODO 지도에 그려줄 때 처리할 로직들
+                    when (state) {
+                        is MapState.Success -> {}
+                        is MapState.Failure -> {}
+                        is MapState.NetworkFailure -> {}
+                        is MapState.NotFoundSearchResults -> {}
+                        is MapState.Loading -> {}
+                    }
+                }
+            }
+        }
     }
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/map/MapState.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/map/MapState.kt
@@ -1,0 +1,11 @@
+package com.lighthouse.presentation.ui.map
+
+import com.lighthouse.presentation.model.BrandPlaceInfoUiModel
+
+sealed class MapState {
+    data class Success(val brandPlaceInfoUiModel: List<BrandPlaceInfoUiModel>) : MapState()
+    object Loading : MapState()
+    object NotFoundSearchResults : MapState()
+    object NetworkFailure : MapState()
+    object Failure : MapState()
+}

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/map/MapViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/map/MapViewModel.kt
@@ -14,13 +14,7 @@ class MapViewModel @Inject constructor(
     private val getBrandPlaceInfosUseCase: GetBrandPlaceInfosUseCase
 ) : ViewModel() {
 
-    // TODO 임시 데이터 변경 필요
-    private val brandList = arrayListOf<String>().apply {
-        add("스타벅스")
-        add("베스킨라빈스")
-        add("BHC")
-        add("BBQ")
-    }
+    private val brandList = arrayListOf("스타벅스", "베스킨라빈스", "BHC", "BBQ")
 
     init {
         viewModelScope.launch {

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/map/MapViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/map/MapViewModel.kt
@@ -1,11 +1,14 @@
 package com.lighthouse.presentation.ui.map
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.lighthouse.domain.model.CustomError
 import com.lighthouse.domain.usecase.GetBrandPlaceInfosUseCase
 import com.lighthouse.presentation.mapper.toPresentation
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -16,15 +19,23 @@ class MapViewModel @Inject constructor(
 
     private val brandList = arrayListOf("스타벅스", "베스킨라빈스", "BHC", "BBQ")
 
+    private val _state: MutableStateFlow<MapState> = MutableStateFlow(MapState.Loading)
+    val state: StateFlow<MapState> = _state.asStateFlow()
+
     init {
         viewModelScope.launch {
             for (query in brandList) {
                 getBrandPlaceInfosUseCase(query, "37.2840", "127.1071", "500", 5)
                     .onSuccess { brandPlaceInfos ->
-                        val brandPlaceInfoUiModels = brandPlaceInfos.map { it.toPresentation() }
-                        Log.d("TAG", "브랜드 리스트 갖고 오기 성공 -> $brandPlaceInfoUiModels")
+                        _state.value = MapState.Success(brandPlaceInfos.map { it.toPresentation() })
                     }
-                    .onFailure { Log.d("TAG", " 브랜드 리스트 갖고 오기 실패 -> $it") }
+                    .onFailure { throwable ->
+                        when (throwable) {
+                            CustomError.NetworkFailure -> _state.value = MapState.NetworkFailure
+                            CustomError.NotFoundBrandPlaceInfos -> _state.value = MapState.NotFoundSearchResults
+                            else -> _state.value = MapState.Failure
+                        }
+                    }
             }
         }
     }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/map/MapViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/map/MapViewModel.kt
@@ -1,5 +1,6 @@
 package com.lighthouse.presentation.ui.map
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.lighthouse.domain.model.CustomError
@@ -23,20 +24,25 @@ class MapViewModel @Inject constructor(
     val state: StateFlow<MapState> = _state.asStateFlow()
 
     init {
+        getBrandPlaceInfos(brandList)
+    }
+
+    fun getBrandPlaceInfos(brandList: List<String>) {
         viewModelScope.launch {
-            for (query in brandList) {
-                getBrandPlaceInfosUseCase(query, "37.2840", "127.1071", "500", 5)
-                    .onSuccess { brandPlaceInfos ->
-                        _state.value = MapState.Success(brandPlaceInfos.map { it.toPresentation() })
+            getBrandPlaceInfosUseCase(brandList, "37.2840", "127.1071", "500", 5)
+                .mapCatching { it.toPresentation() }
+                .onSuccess { brandPlaceInfos ->
+                    Log.d("TAG", "success -> $brandPlaceInfos")
+                    _state.value = MapState.Success(brandPlaceInfos)
+                }
+                .onFailure { throwable ->
+                    Log.d("TAG", "throwable -> $throwable")
+                    when (throwable) {
+                        CustomError.NetworkFailure -> _state.value = MapState.NetworkFailure
+                        CustomError.NotFoundBrandPlaceInfos -> _state.value = MapState.NotFoundSearchResults
+                        else -> _state.value = MapState.Failure
                     }
-                    .onFailure { throwable ->
-                        when (throwable) {
-                            CustomError.NetworkFailure -> _state.value = MapState.NetworkFailure
-                            CustomError.NotFoundBrandPlaceInfos -> _state.value = MapState.NotFoundSearchResults
-                            else -> _state.value = MapState.Failure
-                        }
-                    }
-            }
+                }
         }
     }
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/map/MapViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/map/MapViewModel.kt
@@ -20,8 +20,8 @@ class MapViewModel @Inject constructor(
 
     private val brandList = arrayListOf("스타벅스", "베스킨라빈스", "BHC", "BBQ")
 
-    private val _state: MutableStateFlow<MapState> = MutableStateFlow(MapState.Loading)
-    val state: StateFlow<MapState> = _state.asStateFlow()
+    var state: MutableStateFlow<MapState> = MutableStateFlow(MapState.Loading)
+        private set
 
     init {
         getBrandPlaceInfos(brandList)
@@ -33,14 +33,14 @@ class MapViewModel @Inject constructor(
                 .mapCatching { it.toPresentation() }
                 .onSuccess { brandPlaceInfos ->
                     Log.d("TAG", "success -> $brandPlaceInfos")
-                    _state.value = MapState.Success(brandPlaceInfos)
+                    state.value = MapState.Success(brandPlaceInfos)
                 }
                 .onFailure { throwable ->
                     Log.d("TAG", "throwable -> $throwable")
                     when (throwable) {
-                        CustomError.NetworkFailure -> _state.value = MapState.NetworkFailure
-                        CustomError.NotFoundBrandPlaceInfos -> _state.value = MapState.NotFoundSearchResults
-                        else -> _state.value = MapState.Failure
+                        CustomError.NetworkFailure -> state.value = MapState.NetworkFailure
+                        CustomError.NotFoundBrandPlaceInfos -> state.value = MapState.NotFoundSearchResults
+                        else -> state.value = MapState.Failure
                     }
                 }
         }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/map/MapViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/map/MapViewModel.kt
@@ -1,6 +1,5 @@
 package com.lighthouse.presentation.ui.map
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.lighthouse.domain.model.CustomError
@@ -8,8 +7,6 @@ import com.lighthouse.domain.usecase.GetBrandPlaceInfosUseCase
 import com.lighthouse.presentation.mapper.toPresentation
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -32,11 +29,9 @@ class MapViewModel @Inject constructor(
             getBrandPlaceInfosUseCase(brandList, "37.2840", "127.1071", "500", 5)
                 .mapCatching { it.toPresentation() }
                 .onSuccess { brandPlaceInfos ->
-                    Log.d("TAG", "success -> $brandPlaceInfos")
                     state.value = MapState.Success(brandPlaceInfos)
                 }
                 .onFailure { throwable ->
-                    Log.d("TAG", "throwable -> $throwable")
                     when (throwable) {
                         CustomError.NetworkFailure -> state.value = MapState.NetworkFailure
                         CustomError.NotFoundBrandPlaceInfos -> state.value = MapState.NotFoundSearchResults

--- a/presentation/src/test/kotlin/com/lighthouse/presentation/ui/map/MapViewModelTest.kt
+++ b/presentation/src/test/kotlin/com/lighthouse/presentation/ui/map/MapViewModelTest.kt
@@ -1,0 +1,92 @@
+package com.lighthouse.presentation.ui.map
+
+import com.google.common.truth.Truth
+import com.lighthouse.domain.model.BrandPlaceInfo
+import com.lighthouse.domain.model.CustomError
+import com.lighthouse.domain.usecase.GetBrandPlaceInfosUseCase
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.jupiter.api.DisplayName
+
+@ExperimentalCoroutinesApi
+class MapViewModelTest {
+
+    private val getBrandPlaceInfosUseCase: GetBrandPlaceInfosUseCase = mockk(relaxed = true)
+
+    private val dispatcher: TestDispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    @DisplayName("[성공] 검색 결과를 갖고오는데 성공하면 MapState는 Success가 된다")
+    fun getBrandPlaceInfoSuccess() {
+        // given
+        coEvery {
+            getBrandPlaceInfosUseCase(brandKeyword, "37.2840", "127.1071", "500", 5)
+        } returns Result.success(brandPlaceInfo)
+
+        // when
+        val viewModel = MapViewModel(getBrandPlaceInfosUseCase)
+        viewModel.getBrandPlaceInfos(brandKeyword)
+        val actual = viewModel.state.value
+
+        // then
+        Truth.assertThat(actual).isInstanceOf(MapState.Success::class.java)
+    }
+
+    @Test
+    @DisplayName("[실패] 검색 결과가 존재하지 않는다면 MapState는 NotFoundSearchResults가 된다")
+    fun getBrandPlaceInfoNotFoundSearchResults() {
+        // given
+        coEvery {
+            getBrandPlaceInfosUseCase(brandKeyword, "37.2840", "127.1071", "500", 5)
+        } returns Result.failure(CustomError.NotFoundBrandPlaceInfos)
+
+        // when
+        val viewModel = MapViewModel(getBrandPlaceInfosUseCase)
+        viewModel.getBrandPlaceInfos(brandKeyword)
+        val actual = viewModel.state.value
+
+        // then
+        Truth.assertThat(actual).isInstanceOf(MapState.NotFoundSearchResults::class.java)
+    }
+
+    @Test
+    @DisplayName("[실패] 네트워트 연결이 문제가 생긴다면 MapState는 NetworkFailure가 된다.")
+    fun getBrandPlaceInfoNetworkError() {
+        // given
+        coEvery {
+            getBrandPlaceInfosUseCase(brandKeyword, "37.2840", "127.1071", "500", 5)
+        } returns Result.failure(CustomError.NetworkFailure)
+
+        // when
+        val viewModel = MapViewModel(getBrandPlaceInfosUseCase)
+        viewModel.getBrandPlaceInfos(brandKeyword)
+        val actual = viewModel.state.value
+
+        // then
+        Truth.assertThat(actual).isInstanceOf(MapState.NetworkFailure::class.java)
+    }
+
+    companion object {
+        private val brandKeyword: List<String> = listOf("스타벅스", "베스킨라빈스", "BBQ")
+        private val brandPlaceInfo: List<BrandPlaceInfo> = listOf(BrandPlaceInfo("서울 중구", "스타벅스", "", "", "", ""))
+    }
+}


### PR DESCRIPTION
resolved: #33 

## 작업 내용

- Junit5 적용
- 카카오 검색에서 성공 실패 로직 테스트
- ViewModel 에서 검색 키워드를 for문으로 돌렸는데 이 부분은 UseCase에서 하고 하나로 합쳐서 반환하는게 맞다고 판단해서 로직 위치 수정

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정

### mock 테스트 코드 작성 관련해서 월요일날에 BEEP-Tech에 정리해두겠습니다!