### PR TITLE
스플래시 화면, primary color가 될 분홍색 조정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.BEEP"
+        android:theme="@style/Theme.BEEP.Splash"
         tools:targetApi="31">
 
         <meta-data

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.BEEP.Splash"
+        android:theme="@style/Theme.BEEP"
         tools:targetApi="31">
 
         <meta-data

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -3,6 +3,7 @@ import org.gradle.api.artifacts.dsl.DependencyHandler
 object Versions {
     const val APP_COMPAT = "1.5.1"
     const val CORE = "1.9.0"
+    const val CORE_SPLASH = "1.0.0"
     const val CONSTRAINT_LAYOUT = "2.1.4"
     const val MATERIAL = "1.7.0"
     const val VIEWMODEL_KTX = "2.5.1"
@@ -46,6 +47,7 @@ object Versions {
 object Libraries {
     // androidX + KTX
     private const val CORE = "androidx.core:core-ktx:${Versions.CORE}"
+    private const val CORE_SPLASH = "androidx.core:core-splashscreen:${Versions.CORE_SPLASH}"
     private const val APP_COMPAT = "androidx.appcompat:appcompat:${Versions.APP_COMPAT}"
     private const val CONSTRAINT_LAYOUT = "androidx.constraintlayout:constraintlayout:${Versions.CONSTRAINT_LAYOUT}"
     private const val MATERIAL = "com.google.android.material:material:${Versions.MATERIAL}"
@@ -92,6 +94,7 @@ object Libraries {
 
     val VIEW_LIBRARIES = arrayListOf(
         CORE,
+        CORE_SPLASH,
         APP_COMPAT,
         CONSTRAINT_LAYOUT,
         MATERIAL,

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -4,15 +4,15 @@
         <activity
             android:name=".ui.signin.SignInActivity"
             android:exported="true">
-        </activity>
-        <activity
-            android:name=".ui.main.MainActivity"
-            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+        <activity
+            android:name=".ui.main.MainActivity"
+            android:exported="true">
 
             <meta-data
                 android:name="android.app.lib_name"

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     <application>
         <activity
             android:name=".ui.signin.SignInActivity"
+            android:theme="@style/Theme.BEEP.Splash"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
         <activity
             android:name=".ui.signin.SignInActivity"
             android:theme="@style/Theme.BEEP.Splash"
+            android:noHistory="true"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/signin/SignInActivity.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/signin/SignInActivity.kt
@@ -2,6 +2,7 @@ package com.lighthouse.presentation.ui.signin
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.commit
 import com.lighthouse.presentation.R
@@ -14,6 +15,7 @@ class SignInActivity : AppCompatActivity() {
     private val signInFragment by lazy { SignInFragment() }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
         super.onCreate(savedInstanceState)
         binding = DataBindingUtil.setContentView(this, R.layout.activity_sign_in)
         supportFragmentManager.commit {

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/signin/SignInFragment.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/signin/SignInFragment.kt
@@ -51,7 +51,11 @@ class SignInFragment : Fragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        auth.currentUser?.let { gotoMain() } ?: initGoogleLogin()
+        if (auth.currentUser == null) {
+            initGoogleLogin()
+        } else {
+            gotoMain()
+        }
     }
 
     private fun initGoogleLogin() {

--- a/presentation/src/main/res/drawable/bg_splash.xml
+++ b/presentation/src/main/res/drawable/bg_splash.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/beep_pink" />
+    <item
+        android:drawable="@drawable/ic_splash_beep"
+        android:gravity="center" />
+</layer-list>

--- a/presentation/src/main/res/drawable/ic_splash_beep.xml
+++ b/presentation/src/main/res/drawable/ic_splash_beep.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="72dp"
+    android:height="72dp"
+    android:viewportWidth="72"
+    android:viewportHeight="72">
+  <path
+      android:pathData="M44.205,20V38.93H49V20H44.205ZM25.319,40.266V54H49V40.266H44.132V43.421H30.15V40.266H25.319ZM30.15,47.207H44.132V50.103H30.15V47.207ZM21,21.559V37.817H30.956V21.559H27.039V25.939H24.99V21.559H21ZM24.99,29.688H27.039V33.919H24.99V29.688ZM32.493,21.559V37.817H42.302V21.559H38.386V25.939H36.446V21.559H32.493ZM36.446,29.688H38.386V33.919H36.446V29.688Z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/presentation/src/main/res/layout/fragment_sign_in.xml
+++ b/presentation/src/main/res/layout/fragment_sign_in.xml
@@ -10,7 +10,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="#E91E63"
+        android:background="@color/beep_pink"
         tools:context=".ui.signin.SignInFragment">
 
         <com.google.android.gms.common.SignInButton

--- a/presentation/src/main/res/values/colors.xml
+++ b/presentation/src/main/res/values/colors.xml
@@ -7,5 +7,10 @@
     <color name="error">#E93B14</color>
     <color name="surface_1">#F5F5F5</color>
 
-    <color name="beep_pink">#FF2869</color>
+    <color name="beep_pink">#EF2C67</color>
+
+    <color name="gray_200">#EAEAEA</color>
+    <color name="gray_400">#B8B8B8</color>
+    <color name="gray_500">#8C8C8C</color>
+
 </resources>

--- a/presentation/src/main/res/values/colors.xml
+++ b/presentation/src/main/res/values/colors.xml
@@ -6,4 +6,6 @@
 
     <color name="error">#E93B14</color>
     <color name="surface_1">#F5F5F5</color>
+
+    <color name="beep_pink">#FF2869</color>
 </resources>

--- a/presentation/src/main/res/values/themes.xml
+++ b/presentation/src/main/res/values/themes.xml
@@ -5,4 +5,10 @@
     </style>
 
     <style name="Theme.BEEP" parent="Base.Theme.BEEP" />
+
+    <style name="Theme.BEEP.Splash" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@color/beep_pink</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_splash_beep</item>
+        <item name="postSplashScreenTheme">@style/Theme.BEEP</item>
+    </style>
 </resources>


### PR DESCRIPTION
resolved: #37 

## 작업 내용

- [SplashScreen](https://developer.android.com/reference/kotlin/androidx/core/splashscreen/SplashScreen)으로 스플래시 화면 구성
- primary color 조정하여 설정, 디자인 파일에서 사용한 회색들 설정
    - EAEAEA: 메모창, 칩 
    - B8B8B8: 더보기 
    - 8C8C8C: 브랜드, 날짜 

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정

## 동작 화면

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/69582122/201664097-986657f9-e911-422c-9da1-df5bade189a6.gif)


## 특이 사항

- 안드로이드 12 이하에서 스플래시 정상 출력은 확인했지만, 에뮬레이터에서 구글 로그인이 되지 않아서 로그인 후 MainActivity로 넘어가는 부분은 확인하지 못했습니다. (될 것 같긴 해요)
- 가지고 있는 안드로이드 10 기기에서 확인해보려고 했는데... USB 접촉이 좋지 않아 디버깅 못해봤습니다. 
- 스플래시 출력 속도가 너무 빠른 감이 있긴 한데, SplashScreen에서 지속시간을 지정하는 것은 API 31 이상부터 가능합니다. 한다면 다른 방법을 찾아봐야 함


