### PR TITLE
임시 UseCase 를 사용한 기프티콘 호출

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -118,7 +118,7 @@ object Libraries {
         NAVER_MAP,
         PLAY_SERVICES_LOCATION,
         GLIDE,
-        ZXING
+        ZXING,
         VIEW_PAGER2
     )
     val DATA_LIBRARIES = arrayListOf(

--- a/domain/src/main/java/com/lighthouse/domain/usecase/GetGifticonUseCase.kt
+++ b/domain/src/main/java/com/lighthouse/domain/usecase/GetGifticonUseCase.kt
@@ -1,11 +1,27 @@
 package com.lighthouse.domain.usecase
 
 import com.lighthouse.domain.model.Gifticon
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import java.util.Date
+import javax.inject.Inject
 
-class GetGifticonUseCase {
+class GetGifticonUseCase @Inject constructor() {
 
-    operator fun invoke(id: String): Gifticon {
-        return Gifticon("", "", "", "", Date(), "", true, 0, "", false)
+    // TODO (테스트 용 FAKE 제거)
+    operator fun invoke(id: String): Flow<Gifticon> {
+        return flowOf(
+            Gifticon(
+                id,
+                "",
+                "딸기마카롱설빙",
+                "설빙", Date(),
+                "998935552189",
+                true,
+                50000,
+                "삡 그리고 다운 요 삡 그리고 다운",
+                false
+            )
+        )
     }
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/extra/Extras.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/extra/Extras.kt
@@ -5,4 +5,6 @@ object Extras {
     const val GallerySelection = "Extra.Selection"
 
     const val RecognizedText = "Extra.Recognized.Text"
+
+    const val KEY_GIFTICON_ID = "Extra.GifticonDetail.KeyGifticonId"
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/GifticonListFragment.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/GifticonListFragment.kt
@@ -1,11 +1,31 @@
 package com.lighthouse.presentation.ui.gifticonlist
 
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
 import androidx.fragment.app.Fragment
 import com.lighthouse.presentation.R
 import com.lighthouse.presentation.databinding.FragmentGifticonListBinding
+import com.lighthouse.presentation.extra.Extras.KEY_GIFTICON_ID
 import com.lighthouse.presentation.ui.common.viewBindings
+import com.lighthouse.presentation.ui.detailgifticon.GifticonDetailActivity
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class GifticonListFragment : Fragment(R.layout.fragment_gifticon_list) {
 
     private val binding by viewBindings(FragmentGifticonListBinding::bind)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // TODO (테스트 용 코드 제거)
+        binding.btnTest.setOnClickListener {
+            startActivity(
+                Intent(requireContext(), GifticonDetailActivity::class.java).apply {
+                    putExtra(KEY_GIFTICON_ID, "테스트 중입니다아")
+                }
+            )
+        }
+    }
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/main/MainActivity.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/main/MainActivity.kt
@@ -17,7 +17,9 @@ import com.lighthouse.presentation.ui.gifticonlist.GifticonListFragment
 import com.lighthouse.presentation.ui.home.HomeFragment
 import com.lighthouse.presentation.ui.main.event.MainDirections
 import com.lighthouse.presentation.ui.setting.SettingFragment
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityMainBinding

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/main/MainViewModel.kt
@@ -4,11 +4,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.lighthouse.presentation.R
 import com.lighthouse.presentation.ui.main.event.MainDirections
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class MainViewModel : ViewModel() {
+@HiltViewModel
+class MainViewModel @Inject constructor() : ViewModel() {
 
     val directionsFlow = MutableSharedFlow<MainDirections>()
 

--- a/presentation/src/main/res/layout/fragment_gifticon_list.xml
+++ b/presentation/src/main/res/layout/fragment_gifticon_list.xml
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <TextView
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_test"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toTopOf="parent"
+            android:text="상세화면 테스트"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            android:text="목록"/>
-
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
resolved: #58 

## 작업 내용

- `MainActivity` 및 `MainViewModel` 에 Hilt 어노테이션 추가
- `GifticonListFragment` 에 상세 화면으로 이동하기 위한 임시 버튼 추가
- 임시 UseCase 에서 기프티콘 정보 불러와서 화면에 표시

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정

## 동작 화면

> `Manifest.xml` 에서 **intent-filter** 를 `MainActivity` 로 이동시킨 후 실행하세요

목록 탭으로 이동하여 버튼 누르면 상세 화면으로 이동

<img src="https://user-images.githubusercontent.com/44221447/202397044-2ee1319c-2c43-4c6a-bd7c-3b14310469f7.png" width="33%" />

## 버그

`Dependencies` 에 누락된 콤마 추가
