### PR TITLE
다크 테마 색상 적용 및 화면 세로 고정 설정

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
 
         <activity
             android:name=".ui.security.SecurityActivity"
+            android:screenOrientation="portrait"
             android:exported="true">
         </activity>
         <activity
@@ -18,6 +19,7 @@
         </activity>
         <activity
             android:name=".ui.main.MainActivity"
+            android:screenOrientation="portrait"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -28,13 +30,14 @@
                 android:name="android.app.lib_name"
                 android:value="" />
         </activity>
-        <activity android:name=".ui.addgifticon.AddGifticonActivity" />
-        <activity android:name=".ui.cropgifticon.CropGifticonActivity" android:exported="true"/>
-        <activity android:name=".ui.gallery.GalleryActivity"/>
-        <activity android:name=".ui.detailgifticon.GifticonDetailActivity" />
+        <activity android:name=".ui.addgifticon.AddGifticonActivity" android:screenOrientation="portrait" />
+        <activity android:name=".ui.cropgifticon.CropGifticonActivity" android:exported="true" android:screenOrientation="portrait" />
+        <activity android:name=".ui.gallery.GalleryActivity" android:screenOrientation="portrait" />
+        <activity android:name=".ui.detailgifticon.GifticonDetailActivity" android:screenOrientation="portrait" />
 
         <activity
             android:name=".ui.map.MapActivity"
+            android:screenOrientation="portrait"
             android:exported="true" />
     </application>
 

--- a/presentation/src/main/res/values-night/themes.xml
+++ b/presentation/src/main/res/values-night/themes.xml
@@ -1,10 +1,13 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
     <!-- Base application theme. -->
     <style name="Theme.BEEP" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Customize your dark theme here. -->
-        <item name="colorPrimary">@color/beep_pink</item>
-        <item name="colorPrimaryDark">@color/beep_pink</item>
-        <item name="colorAccent">@color/beep_pink</item>
+        <item name="colorPrimary">@color/beep_pink_dark</item>
+        <item name="colorPrimaryDark">@color/beep_pink_dark</item>
+        <item name="colorOnPrimary">?attr/colorOnSurface</item>
+        <item name="colorSecondary">@color/beep_pink_dark</item>
+        <item name="colorOnSecondary">@color/white</item>
+        <item name="android:statusBarColor">?attr/colorSurface</item>
     </style>
 
     <style name="Theme.BEEP.EditText" parent="Widget.AppCompat.EditText">

--- a/presentation/src/main/res/values/colors.xml
+++ b/presentation/src/main/res/values/colors.xml
@@ -4,11 +4,13 @@
     <color name="white">#FFFFFFFF</color>
     <color name="gray">#8C8C8C</color>
     <color name="light_gray">#DDDDDD</color>
+    <color name="dark_gray">#2D2D2D</color>
 
     <color name="error">#E93B14</color>
     <color name="surface_1">#F5F5F5</color>
 
     <color name="beep_pink">#EF2C67</color>
+    <color name="beep_pink_dark">#EF386F</color>
 
     <color name="gray_200">#EAEAEA</color>
     <color name="gray_400">#B8B8B8</color>

--- a/presentation/src/main/res/values/themes.xml
+++ b/presentation/src/main/res/values/themes.xml
@@ -4,6 +4,8 @@
         <item name="colorPrimary">@color/beep_pink</item>
         <item name="colorOnPrimary">@color/white</item>
         <item name="colorPrimaryDark">@color/beep_pink</item>
+        <item name="colorSecondary">@color/beep_pink</item>
+        <item name="colorOnSecondary">@color/white</item>
         <item name="materialButtonStyle">@style/BEEP.Component.Button</item>
         <item name="toolbarStyle">@style/BEEP.Component.Toolbar</item>
     </style>


### PR DESCRIPTION
resolved: #97

## 작업 내용

- 메인 색상 명도 변경
- 다크모드 테마 색상 지정
- 세로 화면 고정

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정

## 동작 화면

<img src="https://user-images.githubusercontent.com/44221447/203491264-9d7e17d3-6a9a-405b-ae29-d04c824ef707.png" width="33%" />
