### PR TITLE
기프티콘 사용 기록 표시

### DIFF
--- a/data/src/main/java/com/lighthouse/repository/GifticonRepositoryImpl.kt
+++ b/data/src/main/java/com/lighthouse/repository/GifticonRepositoryImpl.kt
@@ -36,7 +36,11 @@ class GifticonRepositoryImpl @Inject constructor(
     override fun getUsageHistory(gifticonId: String): Flow<DbResult<List<UsageHistory>>> = flow {
         emit(DbResult.Loading)
         gifticonLocalDataSource.getUsageHistory(gifticonId).collect {
-            emit(DbResult.Success(it))
+            if (it.isEmpty()) {
+                emit(DbResult.Empty)
+            } else {
+                emit(DbResult.Success(it))
+            }
         }
     }.catch { e ->
         emit(DbResult.Failure(e))

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailActivity.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailActivity.kt
@@ -30,6 +30,7 @@ class GifticonDetailActivity : AppCompatActivity() {
     private val viewModel: GifticonDetailViewModel by viewModels()
 
     private lateinit var checkEditDialog: AlertDialog
+    private lateinit var usageHistoryDialog: AlertDialog
     private lateinit var useGifticonDialog: UseGifticonDialog
 
     private val usageHistoryAdapter by lazy { UsageHistoryAdapter() }
@@ -68,13 +69,6 @@ class GifticonDetailActivity : AppCompatActivity() {
                     GifticonDetailMode.EDIT -> {
                         binding.btnUseGifticon.text = getString(R.string.gifticon_detail_edit_mode_button_text)
                     }
-                }
-            }
-        }
-        repeatOnStarted {
-            viewModel.usageHistory.collect { histories ->
-                if (histories != null) {
-                    usageHistoryAdapter.submitList(histories)
                 }
             }
         }
@@ -139,17 +133,20 @@ class GifticonDetailActivity : AppCompatActivity() {
     }
 
     private fun showUsageHistoryDialog() {
-        val usageHistoryView = DataBindingUtil.inflate<DialogUsageHistoryBinding>(
-            LayoutInflater.from(this),
-            R.layout.dialog_usage_history,
-            null,
-            false
-        )
-        usageHistoryView.rvUsageHistory.adapter = usageHistoryAdapter
-        Timber.tag("usageHistory").d("${usageHistoryAdapter.currentList}")
-        AlertDialog.Builder(this)
-            .setView(usageHistoryView.root)
-            .show()
+        if (::usageHistoryDialog.isInitialized.not()) {
+            val usageHistoryView = DataBindingUtil.inflate<DialogUsageHistoryBinding>(
+                LayoutInflater.from(this),
+                R.layout.dialog_usage_history,
+                null,
+                false
+            )
+            usageHistoryView.vm = viewModel
+            usageHistoryView.rvUsageHistory.adapter = usageHistoryAdapter
+            Timber.tag("usageHistory").d("${usageHistoryAdapter.currentList}")
+            usageHistoryDialog = AlertDialog.Builder(this).setView(usageHistoryView.root).create()
+        }
+
+        usageHistoryDialog.show()
     }
 
     private fun showInvalidDialog() {

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailViewModel.kt
@@ -100,7 +100,8 @@ class GifticonDetailViewModel @Inject constructor(
             GifticonDetailMode.UNUSED -> {
                 viewModelScope.launch {
                     if (gifticon.value?.isCashCard == true) {
-                        useCashCardGifticonUseCase(gifticonId, amountToUse.value)
+//                        useCashCardGifticonUseCase(gifticonId, amountToUse.value) // TODO 이걸로 사용해야 함
+                        useGifticonUseCase(gifticonId) // TODO 이건 제거
                     } else {
                         useGifticonUseCase(gifticonId)
                     }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailViewModel.kt
@@ -45,7 +45,6 @@ class GifticonDetailViewModel @Inject constructor(
     }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
     private val usageHistoryDbResult = getUsageHistoryUseCase(gifticonId)
-        .stateIn(viewModelScope, SharingStarted.Eagerly, DbResult.Loading)
 
     val usageHistory = usageHistoryDbResult.transform {
         if (it is DbResult.Success) {

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.lighthouse.domain.model.DbResult
 import com.lighthouse.domain.usecase.GetGifticonUseCase
+import com.lighthouse.domain.usecase.GetUsageHistoriesUseCase
 import com.lighthouse.domain.usecase.UnUseGifticonUseCase
 import com.lighthouse.domain.usecase.UseCashCardGifticonUseCase
 import com.lighthouse.domain.usecase.UseGifticonUseCase
@@ -26,23 +27,37 @@ import javax.inject.Inject
 class GifticonDetailViewModel @Inject constructor(
     stateHandle: SavedStateHandle,
     getGifticonUseCase: GetGifticonUseCase,
+    getUsageHistoryUseCase: GetUsageHistoriesUseCase,
     private val useGifticonUseCase: UseGifticonUseCase,
     private val useCashCardGifticonUseCase: UseCashCardGifticonUseCase,
     private val unUseGifticonUseCase: UnUseGifticonUseCase
 ) : ViewModel() {
 
     private val gifticonId = stateHandle.get<String>(KEY_GIFTICON_ID) ?: error("Gifticon id is null")
-    private val dbResult =
+    private val gifticonDbResult =
         getGifticonUseCase(gifticonId).stateIn(viewModelScope, SharingStarted.Eagerly, DbResult.Loading)
 
-    val gifticon = dbResult.transform {
+    val gifticon = gifticonDbResult.transform {
         if (it is DbResult.Success) {
             emit(it.data)
             switchMode(if (it.data.isUsed) GifticonDetailMode.USED else GifticonDetailMode.UNUSED)
         }
     }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
-    val failure = dbResult.transform {
+    private val usageHistoryDbResult = getUsageHistoryUseCase(gifticonId)
+        .stateIn(viewModelScope, SharingStarted.Eagerly, DbResult.Loading)
+
+    val usageHistory = usageHistoryDbResult.transform {
+        if (it is DbResult.Success) {
+            emit(it.data)
+        }
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    val latestUsageHistory = usageHistory.transform {
+        emit(it?.last())
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    val failure = gifticonDbResult.transform {
         if (it is DbResult.Failure) {
             emit(it.throwable)
         }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/dialog/UsageHistoryAdapter.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/dialog/UsageHistoryAdapter.kt
@@ -4,13 +4,13 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.lighthouse.domain.model.UsageHistory
 import com.lighthouse.presentation.R
+import com.lighthouse.presentation.adapter.BindableListAdapter
 import com.lighthouse.presentation.databinding.ItemUsageHistoryBinding
 
-class UsageHistoryAdapter : ListAdapter<UsageHistory, UsageHistoryAdapter.UsageHistoryViewHolder>(diffUtil) {
+class UsageHistoryAdapter : BindableListAdapter<UsageHistory, UsageHistoryAdapter.UsageHistoryViewHolder>(diffUtil) {
 
     class UsageHistoryViewHolder(private val binding: ItemUsageHistoryBinding) :
         RecyclerView.ViewHolder(binding.root) {

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/dialog/UsageHistoryAdapter.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/dialog/UsageHistoryAdapter.kt
@@ -1,0 +1,47 @@
+package com.lighthouse.presentation.ui.detailgifticon.dialog
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.lighthouse.domain.model.UsageHistory
+import com.lighthouse.presentation.R
+import com.lighthouse.presentation.databinding.ItemUsageHistoryBinding
+
+class UsageHistoryAdapter : ListAdapter<UsageHistory, UsageHistoryAdapter.UsageHistoryViewHolder>(diffUtil) {
+
+    class UsageHistoryViewHolder(private val binding: ItemUsageHistoryBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(usageHistory: UsageHistory) {
+            binding.usage = usageHistory
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): UsageHistoryViewHolder {
+        val view = DataBindingUtil.inflate<ItemUsageHistoryBinding>(
+            LayoutInflater.from(parent.context),
+            R.layout.item_usage_history,
+            parent,
+            false
+        )
+        return UsageHistoryViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: UsageHistoryViewHolder, position: Int) {
+        return holder.bind(currentList[position])
+    }
+
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<UsageHistory>() {
+            override fun areItemsTheSame(oldItem: UsageHistory, newItem: UsageHistory): Boolean {
+                return oldItem.date == newItem.date
+            }
+
+            override fun areContentsTheSame(oldItem: UsageHistory, newItem: UsageHistory): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/GifticonListFragment.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/GifticonListFragment.kt
@@ -61,10 +61,22 @@ class GifticonListFragment : Fragment(R.layout.fragment_gifticon_list) {
                             id = "sample3",
                             userId = "mangbaam",
                             name = "어머니는 외계인",
-                            brand = "베스킨라빈스31",
+                            brand = "베스킨라빈스",
                             expireAt = Date(),
                             barcode = "808346588450",
                             isCashCard = false,
+                            balance = 0,
+                            memo = "",
+                            isUsed = true
+                        ),
+                        Gifticon(
+                            id = "sample4",
+                            userId = "mangbaam",
+                            name = "3만원권",
+                            brand = "e마트",
+                            expireAt = Date(),
+                            barcode = "808346588450",
+                            isCashCard = true,
                             balance = 0,
                             memo = "",
                             isUsed = true
@@ -77,7 +89,13 @@ class GifticonListFragment : Fragment(R.layout.fragment_gifticon_list) {
         binding.btnTest.setOnClickListener {
             startActivity(
                 Intent(requireContext(), GifticonDetailActivity::class.java).apply {
-                    putExtra(KEY_GIFTICON_ID, "sample1")
+                    val key = when (binding.rgTestOption.checkedRadioButtonId) {
+                        R.id.rb1 -> "sample1"
+                        R.id.rb2 -> "sample2"
+                        R.id.rb3 -> "sample3"
+                        else -> "sample4"
+                    }
+                    putExtra(KEY_GIFTICON_ID, key)
                 }
             )
         }

--- a/presentation/src/main/res/layout/activity_gifticon_detail.xml
+++ b/presentation/src/main/res/layout/activity_gifticon_detail.xml
@@ -120,7 +120,6 @@
                     android:inputType="textAutoComplete"
                     android:maxLines="1"
                     android:text="@{vm.gifticon.name}"
-                    android:textAppearance="@style/BEEP.TextStyle.H6"
                     app:layout_constraintStart_toStartOf="@id/gl_start"
                     app:layout_constraintTop_toBottomOf="@id/tv_product_name_label"
                     tools:text="딸기마카롱설빙" />
@@ -148,7 +147,6 @@
                     android:inputType="textAutoComplete"
                     android:maxLines="1"
                     android:text="@{vm.gifticon.brand}"
-                    android:textAppearance="@style/BEEP.TextStyle.H6"
                     app:layout_constraintStart_toStartOf="@id/gl_start"
                     app:layout_constraintTop_toBottomOf="@id/tv_brand_label"
                     tools:text="설빙" />
@@ -174,7 +172,7 @@
 
                 <TextView
                     android:id="@+id/tv_expire_date"
-                    style="@style/BEEP.TextStyle.H6"
+                    style="@style/Theme.BEEP.TextView"
                     dateFormat="@{vm.gifticon.expireAt}"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
@@ -191,7 +189,7 @@
                     isVisible="@{vm.gifticon.cashCard &amp;&amp; !vm.gifticon.used}"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    app:constraint_referenced_ids="tv_cash_balance,tv_cash_balance_label"
+                    app:constraint_referenced_ids="tv_cash_balance,tv_cash_balance_label,tv_balance_label,tv_balance"
                     tools:visibility="gone" />
 
                 <TextView
@@ -225,7 +223,7 @@
                     isVisible="@{vm.gifticon.used}"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    app:constraint_referenced_ids="iv_show_all_used_info_button,tv_used_address_label,tv_used_address,tv_used_date_label,tv_used_date,tv_balance_label,tv_balance"
+                    app:constraint_referenced_ids="iv_show_all_used_info_button,tv_used_address_label,tv_used_address,tv_used_date_label,tv_used_date"
                     app:layout_constraintTop_toBottomOf="@id/tv_used_date"
                     tools:visibility="gone" />
 
@@ -240,12 +238,14 @@
 
                 <TextView
                     android:id="@+id/tv_used_address"
+                    style="@style/BEEP.TextStyle.Body1"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="4dp"
                     android:layout_marginEnd="48dp"
                     android:ellipsize="end"
                     android:maxLines="1"
+                    android:text="@{vm.latestUsageHistory.address}"
                     app:layout_constraintEnd_toStartOf="@id/iv_show_all_used_info_button"
                     app:layout_constraintStart_toStartOf="@id/gl_start"
                     app:layout_constraintTop_toBottomOf="@id/tv_used_address_label"
@@ -276,6 +276,8 @@
 
                 <TextView
                     android:id="@+id/tv_used_date"
+                    style="@style/BEEP.TextStyle.Body1"
+                    dateFormat="@{vm.latestUsageHistory.date}"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="4dp"

--- a/presentation/src/main/res/layout/activity_gifticon_detail.xml
+++ b/presentation/src/main/res/layout/activity_gifticon_detail.xml
@@ -158,17 +158,18 @@
                     android:layout_height="wrap_content"
                     app:constraint_referenced_ids="iv_edit_button,tv_expire_date_label,tv_expire_date"
                     app:layout_constraintTop_toBottomOf="@id/tv_expire_date"
-                    tools:visibility="visible" />
+                    tools:visibility="gone" />
 
                 <TextView
                     android:id="@+id/tv_expire_date_label"
-                    android:layout_width="0dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
                     android:text="@string/gifticon_detail_product_expire_date_label"
                     app:layout_constraintEnd_toStartOf="@id/tv_cash_balance_label"
                     app:layout_constraintStart_toStartOf="@id/gl_start"
-                    app:layout_constraintTop_toBottomOf="@id/et_brand" />
+                    app:layout_constraintTop_toBottomOf="@id/et_brand"
+                    app:layout_goneMarginTop="16dp" />
 
                 <TextView
                     android:id="@+id/tv_expire_date"
@@ -189,18 +190,20 @@
                     isVisible="@{vm.gifticon.cashCard &amp;&amp; !vm.gifticon.used}"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    app:constraint_referenced_ids="tv_cash_balance,tv_cash_balance_label,tv_balance_label,tv_balance"
-                    tools:visibility="gone" />
+                    app:constraint_referenced_ids="tv_cash_balance,tv_cash_balance_label"
+                    tools:visibility="visible" />
 
                 <TextView
                     android:id="@+id/tv_cash_balance_label"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
                     android:text="@string/gifticon_detail_cash_type_balance_label"
                     app:layout_constraintBottom_toBottomOf="@id/tv_expire_date_label"
                     app:layout_constraintEnd_toEndOf="@id/gl_end"
                     app:layout_constraintStart_toEndOf="@id/tv_expire_date_label"
-                    app:layout_constraintTop_toTopOf="@id/tv_expire_date_label" />
+                    app:layout_constraintTop_toBottomOf="@id/tv_used_address"
+                    app:layout_goneMarginTop="0dp" />
 
                 <EditText
                     android:id="@+id/tv_cash_balance"
@@ -208,14 +211,15 @@
                     concurrencyFormat="@{vm.gifticon.balance}"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
                     android:background="@null"
                     android:enabled="@{vm.mode == mode.EDIT}"
                     android:importantForAutofill="no"
                     android:inputType="number"
-                    app:layout_constraintBottom_toBottomOf="@id/tv_expire_date"
+                    android:text="@{@string/all_cash_unit(vm.gifticon.balance)}"
                     app:layout_constraintEnd_toEndOf="@id/gl_end"
                     app:layout_constraintStart_toEndOf="@id/tv_expire_date"
-                    app:layout_constraintTop_toTopOf="@id/tv_expire_date"
+                    app:layout_constraintTop_toBottomOf="@id/tv_cash_balance_label"
                     tools:text="3,620원" />
 
                 <androidx.constraintlayout.widget.Group
@@ -266,11 +270,11 @@
 
                 <TextView
                     android:id="@+id/tv_used_date_label"
-                    android:layout_width="0dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
                     android:text="@string/gifticon_detail_used_date_label"
-                    app:layout_constraintEnd_toStartOf="@id/tv_balance_label"
+                    app:layout_constraintEnd_toStartOf="@id/tv_cash_balance_label"
                     app:layout_constraintStart_toStartOf="@id/gl_start"
                     app:layout_constraintTop_toBottomOf="@id/tv_used_address" />
 
@@ -278,34 +282,13 @@
                     android:id="@+id/tv_used_date"
                     style="@style/BEEP.TextStyle.Body1"
                     dateFormat="@{vm.latestUsageHistory.date}"
-                    android:layout_width="0dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="4dp"
-                    app:layout_constraintEnd_toStartOf="@id/tv_balance"
+                    app:layout_constraintEnd_toStartOf="@id/tv_cash_balance"
                     app:layout_constraintStart_toStartOf="@id/gl_start"
                     app:layout_constraintTop_toBottomOf="@id/tv_used_date_label"
                     tools:text="2022.11.08" />
-
-                <TextView
-                    android:id="@+id/tv_balance_label"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:text="@string/gifticon_detail_balance_label"
-                    app:layout_constraintBottom_toBottomOf="@id/tv_used_date_label"
-                    app:layout_constraintEnd_toEndOf="@id/gl_end"
-                    app:layout_constraintStart_toEndOf="@id/tv_used_date_label"
-                    app:layout_constraintTop_toTopOf="@id/tv_used_date_label" />
-
-                <TextView
-                    android:id="@+id/tv_balance"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="4dp"
-                    app:layout_constraintBottom_toBottomOf="@id/tv_used_date"
-                    app:layout_constraintEnd_toEndOf="@id/gl_end"
-                    app:layout_constraintStart_toEndOf="@id/tv_used_date"
-                    app:layout_constraintTop_toTopOf="@id/tv_used_date"
-                    tools:text="0원" />
 
                 <androidx.constraintlayout.widget.Barrier
                     android:id="@+id/barrier_group_bottom"

--- a/presentation/src/main/res/layout/activity_gifticon_detail.xml
+++ b/presentation/src/main/res/layout/activity_gifticon_detail.xml
@@ -153,10 +153,10 @@
 
                 <androidx.constraintlayout.widget.Group
                     android:id="@+id/group_unused"
-                    isVisible="@{!vm.gifticon.used}"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     app:constraint_referenced_ids="iv_edit_button,tv_expire_date_label,tv_expire_date"
+                    app:isVisible="@{!vm.gifticon.used}"
                     app:layout_constraintTop_toBottomOf="@id/tv_expire_date"
                     tools:visibility="gone" />
 
@@ -174,12 +174,12 @@
                 <TextView
                     android:id="@+id/tv_expire_date"
                     style="@style/Theme.BEEP.TextView"
-                    dateFormat="@{vm.gifticon.expireAt}"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="4dp"
                     android:enabled="@{vm.mode==mode.EDIT}"
                     android:onClick="@{() -> vm.expireDateClicked()}"
+                    app:dateFormat="@{vm.gifticon.expireAt}"
                     app:layout_constraintEnd_toStartOf="@id/tv_cash_balance"
                     app:layout_constraintStart_toStartOf="@id/gl_start"
                     app:layout_constraintTop_toBottomOf="@id/tv_expire_date_label"
@@ -187,10 +187,10 @@
 
                 <androidx.constraintlayout.widget.Group
                     android:id="@+id/group_cash_card"
-                    isVisible="@{vm.gifticon.cashCard &amp;&amp; !vm.gifticon.used}"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     app:constraint_referenced_ids="tv_cash_balance,tv_cash_balance_label"
+                    app:isVisible="@{vm.gifticon.cashCard &amp;&amp; !vm.gifticon.used}"
                     tools:visibility="visible" />
 
                 <TextView
@@ -224,10 +224,10 @@
 
                 <androidx.constraintlayout.widget.Group
                     android:id="@+id/group_used"
-                    isVisible="@{vm.gifticon.used}"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     app:constraint_referenced_ids="iv_show_all_used_info_button,tv_used_address_label,tv_used_address,tv_used_date_label,tv_used_date"
+                    app:isVisible="@{vm.gifticon.used}"
                     app:layout_constraintTop_toBottomOf="@id/tv_used_date"
                     tools:visibility="gone" />
 
@@ -257,12 +257,12 @@
 
                 <ImageView
                     android:id="@+id/iv_show_all_used_info_button"
-                    isVisible="@{vm.gifticon.cashCard}"
                     android:layout_width="20dp"
                     android:layout_height="20dp"
                     android:contentDescription="@string/gifticon_detail_show_all_used_info_button_description"
                     android:onClick="@{() -> vm.showAllUsedInfoButtonClicked()}"
                     android:src="@drawable/ic_outline_info"
+                    app:isVisible="@{vm.gifticon.cashCard}"
                     app:layout_constraintBottom_toBottomOf="@id/tv_used_address"
                     app:layout_constraintEnd_toEndOf="@id/gl_end"
                     app:layout_constraintTop_toTopOf="@id/tv_used_address"
@@ -281,10 +281,10 @@
                 <TextView
                     android:id="@+id/tv_used_date"
                     style="@style/BEEP.TextStyle.Body1"
-                    dateFormat="@{vm.latestUsageHistory.date}"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="4dp"
+                    app:dateFormat="@{vm.latestUsageHistory.date}"
                     app:layout_constraintEnd_toStartOf="@id/tv_cash_balance"
                     app:layout_constraintStart_toStartOf="@id/gl_start"
                     app:layout_constraintTop_toBottomOf="@id/tv_used_date_label"

--- a/presentation/src/main/res/layout/dialog_usage_history.xml
+++ b/presentation/src/main/res/layout/dialog_usage_history.xml
@@ -5,6 +5,9 @@
 
     <data>
 
+        <variable
+            name="vm"
+            type="com.lighthouse.presentation.ui.detailgifticon.GifticonDetailViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -70,6 +73,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/divider"
             app:layout_constraintVertical_bias="0"
+            app:setItems="@{vm.usageHistory}"
             tools:itemCount="10"
             tools:listitem="@layout/item_usage_history" />
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/dialog_usage_history.xml
+++ b/presentation/src/main/res/layout/dialog_usage_history.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/tv_usage_date_label"
+            style="@style/BEEP.TextStyle.Subtitle1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="16dp"
+            android:gravity="center"
+            android:text="@string/dialog_usage_history_date_label"
+            app:layout_constraintEnd_toStartOf="@id/tv_usage_address_label"
+            app:layout_constraintHorizontal_weight="0.9"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_usage_address_label"
+            style="@style/BEEP.TextStyle.Subtitle1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="@string/dialog_usage_history_address_label"
+            app:layout_constraintEnd_toStartOf="@id/tv_usage_amount_label"
+            app:layout_constraintHorizontal_weight="1.3"
+            app:layout_constraintStart_toEndOf="@id/tv_usage_date_label"
+            app:layout_constraintTop_toTopOf="@id/tv_usage_date_label" />
+
+        <TextView
+            android:id="@+id/tv_usage_amount_label"
+            style="@style/BEEP.TextStyle.Subtitle1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="@string/dialog_usage_history_amount_label"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_weight="0.8"
+            app:layout_constraintStart_toEndOf="@id/tv_usage_address_label"
+            app:layout_constraintTop_toTopOf="@id/tv_usage_date_label" />
+
+        <View
+            android:id="@+id/divider"
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:layout_marginTop="16dp"
+            android:background="?android:attr/listDivider"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_usage_date_label" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_usage_history"
+            android:layout_width="0dp"
+            android:layout_height="300dp"
+            android:orientation="vertical"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/divider"
+            app:layout_constraintVertical_bias="0"
+            tools:itemCount="10"
+            tools:listitem="@layout/item_usage_history" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/src/main/res/layout/dialog_use_gifticon.xml
+++ b/presentation/src/main/res/layout/dialog_use_gifticon.xml
@@ -154,13 +154,13 @@
                     android:importantForAutofill="no"
                     android:inputType="number"
                     android:maxLength="12"
-                    android:textAppearance="@style/BEEP.TextStyle.H5.OnSurface"
+                    android:textAppearance="@style/BEEP.TextStyle.H5"
                     tools:text="3,000" />
             </com.google.android.material.textfield.TextInputLayout>
 
             <TextView
                 android:id="@+id/tv_balance"
-                style="@style/BEEP.TextStyle.Caption.OnSurface"
+                style="@style/BEEP.TextStyle.Caption"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:gravity="end"

--- a/presentation/src/main/res/layout/fragment_gifticon_list.xml
+++ b/presentation/src/main/res/layout/fragment_gifticon_list.xml
@@ -16,12 +16,48 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <RadioGroup
+            android:id="@+id/rg_test_option"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toTopOf="@id/btn_test"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <RadioButton
+                android:id="@+id/rb1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:text="일반" />
+
+            <RadioButton
+                android:id="@+id/rb2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="금액권" />
+
+            <RadioButton
+                android:id="@+id/rb3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="사용된 일반" />
+
+            <RadioButton
+                android:id="@+id/rb4"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="사용된 금액권" />
+        </RadioGroup>
+
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_add_sample_data"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="30dp"
             android:text="샘플 데이터 추가"
-            app:layout_constraintBottom_toTopOf="@id/btn_test"
+            app:layout_constraintBottom_toTopOf="@id/rg_test_option"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/item_usage_history.xml
+++ b/presentation/src/main/res/layout/item_usage_history.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="usage"
+            type="com.lighthouse.domain.model.UsageHistory" />
+    </data>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingVertical="16dp">
+
+        <TextView
+            android:id="@+id/tv_usage_date"
+            style="@style/BEEP.TextStyle.Body2"
+            dateFormat="@{usage.date}"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.9"
+            android:gravity="center"
+            android:paddingHorizontal="2dp"
+            tools:text="2022.11.08" />
+
+        <TextView
+            android:id="@+id/tv_usage_address"
+            style="@style/BEEP.TextStyle.Body2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1.3"
+            android:gravity="center"
+            android:maxLines="2"
+            android:paddingHorizontal="2dp"
+            android:text="@{usage.address}"
+            tools:text="서울시 용산구" />
+
+        <TextView
+            android:id="@+id/tv_usage_amount"
+            style="@style/BEEP.TextStyle.Body2"
+            concurrencyFormat="@{usage.amount}"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.8"
+            android:gravity="center"
+            android:paddingHorizontal="2dp"
+            tools:text="4,500원" />
+    </LinearLayout>
+</layout>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -139,6 +139,9 @@
     <string name="pin_backspace">Backspace</string>
     <string name="pin_secure_not_use"><u>보안 설정 사용 안 함</u></string>
     <string name="pin_complete">PIN 설정을 완료했습니다</string>
+    <string name="dialog_usage_history_date_label">일자</string>
+    <string name="dialog_usage_history_address_label">위치</string>
+    <string name="dialog_usage_history_amount_label">금액</string>
 
 
 </resources>

--- a/presentation/src/main/res/values/styles.xml
+++ b/presentation/src/main/res/values/styles.xml
@@ -3,57 +3,23 @@
     <!-- TextAppearance -->
     <style name="BEEP.TextStyle.H4" parent="TextAppearance.MaterialComponents.Headline4" />
 
-    <style name="BEEP.TextStyle.H4.OnSurface">
-        <item name="android:textColor">?attr/colorOnSurface</item>
-    </style>
-
     <style name="BEEP.TextStyle.H5" parent="TextAppearance.MaterialComponents.Headline5" />
 
-    <style name="BEEP.TextStyle.H5.OnSurface">
-        <item name="android:textColor">?attr/colorOnSurface</item>
-    </style>
-
     <style name="BEEP.TextStyle.H6" parent="TextAppearance.MaterialComponents.Headline6" /> <!-- 툴바 -->
-
-    <style name="BEEP.TextStyle.H6.OnSurface">
-        <item name="android:textColor">?attr/colorOnSurface</item>
-    </style>
 
     <style name="BEEP.TextStyle.Subtitle1" parent="TextAppearance.MaterialComponents.Subtitle1">
         <item name="android:textSize">14sp</item>
     </style>
 
-    <style name="BEEP.TextStyle.Subtitle1.OnSurface">
-        <item name="android:textColor">?attr/colorOnSurface</item>
-    </style>
+    <style name="BEEP.TextStyle.Body1" parent="TextAppearance.MaterialComponents.Body1" />
 
-    <style name="BEEP.TextStyle.Body1" parent="TextAppearance.MaterialComponents.Body2" />
-
-    <style name="BEEP.TextStyle.Body1.OnSurface">
-        <item name="android:textColor">?attr/colorOnSurface</item>
-    </style>
-
-    <style name="BEEP.TextStyle.Body2" parent="BEEP.TextStyle.Body1">
-        <item name="android:textSize">12sp</item>
-    </style>
-
-    <style name="BEEP.TextStyle.Body2.OnSurface">
-        <item name="android:textColor">?attr/colorOnSurface</item>
-    </style>
+    <style name="BEEP.TextStyle.Body2" parent="TextAppearance.MaterialComponents.Body2" />
 
     <style name="BEEP.TextStyle.Button" parent="TextAppearance.MaterialComponents.Button">
         <item name="android:textSize">20sp</item>
     </style>
 
-    <style name="BEEP.TextStyle.Button.OnSurface">
-        <item name="android:textColor">?attr/colorOnSurface</item>
-    </style>
-
     <style name="BEEP.TextStyle.Caption" parent="TextAppearance.MaterialComponents.Caption" />
-
-    <style name="BEEP.TextStyle.Caption.OnSurface">
-        <item name="android:textColor">?attr/colorOnSurface</item>
-    </style>
 
     <!-- Component -->
     <style name="BEEP.Component.Toolbar" parent="Widget.MaterialComponents.Toolbar">

--- a/presentation/src/main/res/values/themes.xml
+++ b/presentation/src/main/res/values/themes.xml
@@ -16,6 +16,12 @@
 
     <style name="Theme.BEEP.EditText" parent="Widget.AppCompat.EditText">
         <item name="android:textColor">@drawable/tc_on_primary_disabled</item>
+        <item name="android:textAppearance">@style/BEEP.TextStyle.Body1</item>
+    </style>
+
+    <style name="Theme.BEEP.TextView" parent="Widget.AppCompat.TextView">
+        <item name="android:textColor">@drawable/tc_on_primary_disabled</item>
+        <item name="android:textAppearance">@style/BEEP.TextStyle.Body1</item>
     </style>
 
     <style name="Theme.BEEP.Toolbar" parent="Theme.BEEP">


### PR DESCRIPTION
resolved: #95 

## 작업 내용

- 기프티콘 사용 완료 시 가장 최근 정보 화면에 표시
- 금액권인 경우 i 버튼을 누르면 전체 정보를 확인할 수 있는 다이얼로그를 띄움

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정

## 동작 화면

<img src="https://user-images.githubusercontent.com/44221447/203614099-b3db5536-4ecb-47f3-b32a-b90dcfc11787.png" width="33%" />

## 버그

현재 기프티콘 상세화면 레이아웃이 이상합니다. 일반 기프티콘과 금액권 기프티콘 화면을 분리할 예정이라서 일단 PR 올립니다
