### PR TITLE
기프티콘 상세화면 타입 별로 화면 분리

### DIFF
--- a/domain/src/main/java/com/lighthouse/domain/LocationConverter.kt
+++ b/domain/src/main/java/com/lighthouse/domain/LocationConverter.kt
@@ -178,7 +178,7 @@ object LocationConverter {
      * @param dms : 도.분.초
      * @return 도분초를 각각 계산해서 하나의 좌표로 만들어줍니다.
      */
-    private fun convertToDD(dms: Dms) =
+    fun convertToDD(dms: Dms) =
         dms.degree.toDouble() + (dms.minutes.toDouble() / 60.0) + (dms.seconds.toDouble() / 3600.0)
 
     fun toPolygonLatLng(x: Double, y: Double): ArrayList<Pair<Double, Double>> {

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/CashCardGifticonInfoFragment.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/CashCardGifticonInfoFragment.kt
@@ -1,0 +1,19 @@
+package com.lighthouse.presentation.ui.detailgifticon
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import com.lighthouse.presentation.R
+import com.lighthouse.presentation.databinding.FragmentCashCardGifticonInfoBinding
+import com.lighthouse.presentation.ui.common.viewBindings
+
+class CashCardGifticonInfoFragment : Fragment(R.layout.fragment_cash_card_gifticon_info) {
+    private val binding by viewBindings(FragmentCashCardGifticonInfoBinding::bind)
+    private val viewModel: GifticonDetailViewModel by activityViewModels()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.vm = viewModel
+    }
+}

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/CashCardGifticonInfoFragment.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/CashCardGifticonInfoFragment.kt
@@ -15,5 +15,6 @@ class CashCardGifticonInfoFragment : Fragment(R.layout.fragment_cash_card_giftic
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.vm = viewModel
+        binding.lifecycleOwner = viewLifecycleOwner
     }
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailActivity.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailActivity.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.commit
 import androidx.lifecycle.lifecycleScope
 import com.lighthouse.presentation.R
 import com.lighthouse.presentation.databinding.ActivityGifticonDetailBinding
@@ -28,6 +29,9 @@ class GifticonDetailActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityGifticonDetailBinding
     private val viewModel: GifticonDetailViewModel by viewModels()
+
+    private val standardGifticonInfo by lazy { StandardGifticonInfoFragment() }
+    private val cashCardGifticonInfo by lazy { CashCardGifticonInfoFragment() }
 
     private lateinit var checkEditDialog: AlertDialog
     private lateinit var usageHistoryDialog: AlertDialog
@@ -55,6 +59,21 @@ class GifticonDetailActivity : AppCompatActivity() {
         repeatOnStarted {
             viewModel.event.collect { event ->
                 handleEvent(event)
+            }
+        }
+        repeatOnStarted {
+            viewModel.gifticon.collect { gifticon ->
+                gifticon?.let {
+                    if (it.isCashCard) {
+                        supportFragmentManager.commit {
+                            replace(binding.fcvGifticonInfo.id, cashCardGifticonInfo)
+                        }
+                    } else {
+                        supportFragmentManager.commit {
+                            replace(binding.fcvGifticonInfo.id, standardGifticonInfo)
+                        }
+                    }
+                }
             }
         }
         repeatOnStarted {
@@ -121,7 +140,7 @@ class GifticonDetailActivity : AppCompatActivity() {
         SpinnerDatePicker(
             this
         ) { picker, year, month, dayOfMonth ->
-            binding.tvExpireDate.text = getString(R.string.all_date, year, month, dayOfMonth)
+//            binding.tvExpireDate.text = getString(R.string.all_date, year, month, dayOfMonth) // TODO 만료 날짜 설정
             picker.dismiss()
         }.show()
     }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailViewModel.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -87,6 +88,7 @@ class GifticonDetailViewModel @Inject constructor(
     }
 
     fun expireDateClicked() {
+        Timber.tag("gifticon_detail").d("expireDateClicked() 호출")
         event(Event.ExpireDateClicked)
     }
 

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/StandardGifticonInfoFragment.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/StandardGifticonInfoFragment.kt
@@ -15,5 +15,6 @@ class StandardGifticonInfoFragment : Fragment(R.layout.fragment_standard_giftico
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.vm = viewModel
+        binding.lifecycleOwner = viewLifecycleOwner
     }
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/StandardGifticonInfoFragment.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/StandardGifticonInfoFragment.kt
@@ -1,0 +1,19 @@
+package com.lighthouse.presentation.ui.detailgifticon
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import com.lighthouse.presentation.R
+import com.lighthouse.presentation.databinding.FragmentStandardGifticonInfoBinding
+import com.lighthouse.presentation.ui.common.viewBindings
+
+class StandardGifticonInfoFragment : Fragment(R.layout.fragment_standard_gifticon_info) {
+    private val binding by viewBindings(FragmentStandardGifticonInfoBinding::bind)
+    private val viewModel: GifticonDetailViewModel by activityViewModels()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.vm = viewModel
+    }
+}

--- a/presentation/src/main/res/layout/activity_gifticon_detail.xml
+++ b/presentation/src/main/res/layout/activity_gifticon_detail.xml
@@ -97,228 +97,15 @@
                     app:layout_constraintTop_toTopOf="@id/iv_share_button"
                     app:tint="@color/gray" />
 
-                <TextView
-                    android:id="@+id/tv_product_name_label"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="16dp"
-                    android:labelFor="@id/et_product_name"
-                    android:text="@string/gifticon_detail_product_name_label"
-                    app:layout_constraintStart_toStartOf="@id/gl_start"
-                    app:layout_constraintTop_toBottomOf="@id/iv_product_image" />
-
-                <EditText
-                    android:id="@+id/et_product_name"
-                    style="@style/Theme.BEEP.EditText"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="4dp"
-                    android:background="@null"
-                    android:ellipsize="end"
-                    android:enabled="@{vm.mode == mode.EDIT}"
-                    android:importantForAutofill="no"
-                    android:inputType="textAutoComplete"
-                    android:maxLines="1"
-                    android:text="@{vm.gifticon.name}"
-                    app:layout_constraintStart_toStartOf="@id/gl_start"
-                    app:layout_constraintTop_toBottomOf="@id/tv_product_name_label"
-                    tools:text="딸기마카롱설빙" />
-
-                <TextView
-                    android:id="@+id/tv_brand_label"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="16dp"
-                    android:labelFor="@id/et_brand"
-                    android:text="@string/gifticon_detail_product_brand_label"
-                    app:layout_constraintStart_toStartOf="@id/gl_start"
-                    app:layout_constraintTop_toBottomOf="@id/et_product_name" />
-
-                <EditText
-                    android:id="@+id/et_brand"
-                    style="@style/Theme.BEEP.EditText"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="4dp"
-                    android:background="@null"
-                    android:ellipsize="end"
-                    android:enabled="@{vm.mode == mode.EDIT}"
-                    android:importantForAutofill="no"
-                    android:inputType="textAutoComplete"
-                    android:maxLines="1"
-                    android:text="@{vm.gifticon.brand}"
-                    app:layout_constraintStart_toStartOf="@id/gl_start"
-                    app:layout_constraintTop_toBottomOf="@id/tv_brand_label"
-                    tools:text="설빙" />
-
-                <androidx.constraintlayout.widget.Group
-                    android:id="@+id/group_unused"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    app:constraint_referenced_ids="iv_edit_button,tv_expire_date_label,tv_expire_date"
-                    app:isVisible="@{!vm.gifticon.used}"
-                    app:layout_constraintTop_toBottomOf="@id/tv_expire_date"
-                    tools:visibility="gone" />
-
-                <TextView
-                    android:id="@+id/tv_expire_date_label"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="16dp"
-                    android:text="@string/gifticon_detail_product_expire_date_label"
-                    app:layout_constraintEnd_toStartOf="@id/tv_cash_balance_label"
-                    app:layout_constraintStart_toStartOf="@id/gl_start"
-                    app:layout_constraintTop_toBottomOf="@id/et_brand"
-                    app:layout_goneMarginTop="16dp" />
-
-                <TextView
-                    android:id="@+id/tv_expire_date"
-                    style="@style/Theme.BEEP.TextView"
+                <androidx.fragment.app.FragmentContainerView
+                    android:id="@+id/fcv_gifticon_info"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="4dp"
-                    android:enabled="@{vm.mode==mode.EDIT}"
-                    android:onClick="@{() -> vm.expireDateClicked()}"
-                    app:dateFormat="@{vm.gifticon.expireAt}"
-                    app:layout_constraintEnd_toStartOf="@id/tv_cash_balance"
-                    app:layout_constraintStart_toStartOf="@id/gl_start"
-                    app:layout_constraintTop_toBottomOf="@id/tv_expire_date_label"
-                    tools:text="2023.07.23" />
-
-                <androidx.constraintlayout.widget.Group
-                    android:id="@+id/group_cash_card"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    app:constraint_referenced_ids="tv_cash_balance,tv_cash_balance_label"
-                    app:isVisible="@{vm.gifticon.cashCard &amp;&amp; !vm.gifticon.used}"
-                    tools:visibility="visible" />
-
-                <TextView
-                    android:id="@+id/tv_cash_balance_label"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="16dp"
-                    android:text="@string/gifticon_detail_cash_type_balance_label"
-                    app:layout_constraintBottom_toBottomOf="@id/tv_expire_date_label"
-                    app:layout_constraintEnd_toEndOf="@id/gl_end"
-                    app:layout_constraintStart_toEndOf="@id/tv_expire_date_label"
-                    app:layout_constraintTop_toBottomOf="@id/tv_used_address"
-                    app:layout_goneMarginTop="0dp" />
-
-                <EditText
-                    android:id="@+id/tv_cash_balance"
-                    style="@style/Theme.BEEP.EditText"
-                    concurrencyFormat="@{vm.gifticon.balance}"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="4dp"
-                    android:background="@null"
-                    android:enabled="@{vm.mode == mode.EDIT}"
-                    android:importantForAutofill="no"
-                    android:inputType="number"
-                    android:text="@{@string/all_cash_unit(vm.gifticon.balance)}"
-                    app:layout_constraintEnd_toEndOf="@id/gl_end"
-                    app:layout_constraintStart_toEndOf="@id/tv_expire_date"
-                    app:layout_constraintTop_toBottomOf="@id/tv_cash_balance_label"
-                    tools:text="3,620원" />
-
-                <androidx.constraintlayout.widget.Group
-                    android:id="@+id/group_used"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    app:constraint_referenced_ids="iv_show_all_used_info_button,tv_used_address_label,tv_used_address,tv_used_date_label,tv_used_date"
-                    app:isVisible="@{vm.gifticon.used}"
-                    app:layout_constraintTop_toBottomOf="@id/tv_used_date"
-                    tools:visibility="gone" />
-
-                <TextView
-                    android:id="@+id/tv_used_address_label"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="16dp"
-                    android:text="@string/gifticon_detail_used_address_label"
-                    app:layout_constraintStart_toStartOf="@id/gl_start"
-                    app:layout_constraintTop_toBottomOf="@id/et_brand" />
-
-                <TextView
-                    android:id="@+id/tv_used_address"
-                    style="@style/BEEP.TextStyle.Body1"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="4dp"
-                    android:layout_marginEnd="48dp"
-                    android:ellipsize="end"
-                    android:maxLines="1"
-                    android:text="@{vm.latestUsageHistory.address}"
-                    app:layout_constraintEnd_toStartOf="@id/iv_show_all_used_info_button"
-                    app:layout_constraintStart_toStartOf="@id/gl_start"
-                    app:layout_constraintTop_toBottomOf="@id/tv_used_address_label"
-                    tools:text="서울시 용산구 백범로 90라길 올리브영" />
-
-                <ImageView
-                    android:id="@+id/iv_show_all_used_info_button"
-                    android:layout_width="20dp"
-                    android:layout_height="20dp"
-                    android:contentDescription="@string/gifticon_detail_show_all_used_info_button_description"
-                    android:onClick="@{() -> vm.showAllUsedInfoButtonClicked()}"
-                    android:src="@drawable/ic_outline_info"
-                    app:isVisible="@{vm.gifticon.cashCard}"
-                    app:layout_constraintBottom_toBottomOf="@id/tv_used_address"
-                    app:layout_constraintEnd_toEndOf="@id/gl_end"
-                    app:layout_constraintTop_toTopOf="@id/tv_used_address"
-                    app:tint="@color/gray" />
-
-                <TextView
-                    android:id="@+id/tv_used_date_label"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="16dp"
-                    android:text="@string/gifticon_detail_used_date_label"
-                    app:layout_constraintEnd_toStartOf="@id/tv_cash_balance_label"
-                    app:layout_constraintStart_toStartOf="@id/gl_start"
-                    app:layout_constraintTop_toBottomOf="@id/tv_used_address" />
-
-                <TextView
-                    android:id="@+id/tv_used_date"
-                    style="@style/BEEP.TextStyle.Body1"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="4dp"
-                    app:dateFormat="@{vm.latestUsageHistory.date}"
-                    app:layout_constraintEnd_toStartOf="@id/tv_cash_balance"
-                    app:layout_constraintStart_toStartOf="@id/gl_start"
-                    app:layout_constraintTop_toBottomOf="@id/tv_used_date_label"
-                    tools:text="2022.11.08" />
-
-                <androidx.constraintlayout.widget.Barrier
-                    android:id="@+id/barrier_group_bottom"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    app:barrierDirection="bottom"
-                    app:constraint_referenced_ids="group_used,group_unused" />
-
-                <EditText
-                    android:id="@+id/et_memo"
-                    style="@style/Theme.BEEP.EditText"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="16dp"
-                    android:background="@drawable/bg_gifticon_detail_memo"
-                    android:enabled="@{vm.mode == mode.EDIT}"
-                    android:gravity="top"
-                    android:hint="@string/gifticon_detail_memo_description"
-                    android:importantForAutofill="no"
-                    android:inputType="none"
-                    android:minHeight="150dp"
-                    android:padding="16dp"
-                    android:text="@{vm.gifticon.memo}"
-                    android:textAppearance="@style/BEEP.TextStyle.Body1"
-                    android:textColorHint="#616161"
+                    app:layout_constraintBottom_toTopOf="@id/tv_shared_info"
                     app:layout_constraintEnd_toEndOf="@id/gl_end"
                     app:layout_constraintStart_toStartOf="@id/gl_start"
-                    app:layout_constraintTop_toBottomOf="@id/barrier_group_bottom"
-                    tools:text="adfasdfasdfasdfasdf" />
+                    app:layout_constraintTop_toBottomOf="@id/iv_share_button"
+                    tools:layout="@layout/fragment_standard_gifticon_info" />
 
                 <TextView
                     android:id="@+id/tv_shared_info"
@@ -329,7 +116,7 @@
                     app:layout_constraintBottom_toTopOf="@id/btn_use_gifticon"
                     app:layout_constraintEnd_toEndOf="@id/gl_end"
                     app:layout_constraintStart_toStartOf="@id/gl_start"
-                    app:layout_constraintTop_toBottomOf="@id/et_memo"
+                    app:layout_constraintTop_toBottomOf="@id/fcv_gifticon_info"
                     app:layout_constraintVertical_bias="1"
                     tools:text="ⓘ 2022년 11월 8일에 공유된 기프티콘 입니다." />
 
@@ -344,7 +131,7 @@
                     app:layout_constraintEnd_toEndOf="@id/gl_end"
                     app:layout_constraintHorizontal_bias="0.0"
                     app:layout_constraintStart_toStartOf="@id/gl_start"
-                    app:layout_constraintTop_toBottomOf="@id/et_memo"
+                    app:layout_constraintTop_toBottomOf="@id/tv_shared_info"
                     app:layout_constraintVertical_bias="1.0" />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </ScrollView>

--- a/presentation/src/main/res/layout/dialog_usage_history.xml
+++ b/presentation/src/main/res/layout/dialog_usage_history.xml
@@ -73,7 +73,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/divider"
             app:layout_constraintVertical_bias="0"
-            app:reverseLayout="true"
             app:setItems="@{vm.usageHistory}"
             tools:itemCount="10"
             tools:listitem="@layout/item_usage_history" />

--- a/presentation/src/main/res/layout/dialog_usage_history.xml
+++ b/presentation/src/main/res/layout/dialog_usage_history.xml
@@ -73,6 +73,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/divider"
             app:layout_constraintVertical_bias="0"
+            app:reverseLayout="true"
             app:setItems="@{vm.usageHistory}"
             tools:itemCount="10"
             tools:listitem="@layout/item_usage_history" />

--- a/presentation/src/main/res/layout/fragment_cash_card_gifticon_info.xml
+++ b/presentation/src/main/res/layout/fragment_cash_card_gifticon_info.xml
@@ -78,7 +78,7 @@
             android:layout_height="wrap_content"
             app:constraint_referenced_ids="tv_expire_at_label,tv_expire_at,tv_balance_label,et_balance"
             app:isVisible="@{!vm.gifticon.used}"
-            tools:visibility="visible" />
+            tools:visibility="gone" />
 
         <TextView
             android:id="@+id/tv_expire_at_label"
@@ -139,7 +139,7 @@
             android:layout_height="wrap_content"
             app:constraint_referenced_ids="tv_used_address_label,tv_used_address,tv_used_date_label,tv_used_date,iv_show_all_used_info_button"
             app:isVisible="@{vm.gifticon.used}"
-            tools:visibility="gone" />
+            tools:visibility="visible" />
 
         <TextView
             android:id="@+id/tv_used_address_label"
@@ -225,7 +225,7 @@
             android:padding="16dp"
             android:text="@{vm.gifticon.memo}"
             android:textAppearance="@style/BEEP.TextStyle.Body1"
-            android:textColorHint="#616161"
+            android:textColorHint="@color/gray"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/barrier"

--- a/presentation/src/main/res/layout/fragment_cash_card_gifticon_info.xml
+++ b/presentation/src/main/res/layout/fragment_cash_card_gifticon_info.xml
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="vm"
+            type="com.lighthouse.presentation.ui.detailgifticon.GifticonDetailViewModel" />
+
+        <import
+            alias="mode"
+            type="com.lighthouse.presentation.ui.detailgifticon.GifticonDetailMode" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/tv_product_name_label"
+            style="@style/BEEP.TextStyle.Subtitle1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:labelFor="@id/tv_product_name"
+            android:text="@string/gifticon_detail_product_name_label"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <EditText
+            android:id="@+id/tv_product_name"
+            style="@style/Theme.BEEP.EditText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:background="@null"
+            android:ellipsize="end"
+            android:enabled="@{vm.mode == mode.EDIT}"
+            android:importantForAutofill="no"
+            android:inputType="textAutoComplete"
+            android:maxLines="1"
+            android:text="@{vm.gifticon.name}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_product_name_label"
+            tools:text="딸기마카롱설빙" />
+
+        <TextView
+            android:id="@+id/tv_brand_label"
+            style="@style/BEEP.TextStyle.Subtitle1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:labelFor="@id/tv_brand"
+            android:text="@string/gifticon_detail_product_brand_label"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_product_name" />
+
+        <EditText
+            android:id="@+id/et_brand"
+            style="@style/Theme.BEEP.EditText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:background="@null"
+            android:ellipsize="end"
+            android:enabled="@{vm.mode == mode.EDIT}"
+            android:importantForAutofill="no"
+            android:inputType="textAutoComplete"
+            android:maxLines="1"
+            android:text="@{vm.gifticon.brand}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_brand_label"
+            tools:text="설빙" />
+
+        <androidx.constraintlayout.widget.Group
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:constraint_referenced_ids="tv_expire_at_label,tv_expire_at,tv_balance_label,et_balance"
+            app:isVisible="@{!vm.gifticon.used}"
+            tools:visibility="visible" />
+
+        <TextView
+            android:id="@+id/tv_expire_at_label"
+            style="@style/BEEP.TextStyle.Subtitle1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/gifticon_detail_product_expire_date_label"
+            app:layout_constraintEnd_toStartOf="@id/tv_balance_label"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/et_brand" />
+
+        <TextView
+            android:id="@+id/tv_expire_at"
+            style="@style/Theme.BEEP.TextView"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:enabled="@{vm.mode==mode.EDIT}"
+            android:onClick="@{() -> vm.expireDateClicked()}"
+            app:dateFormat="@{vm.gifticon.expireAt}"
+            app:layout_constraintEnd_toStartOf="@id/tv_balance_label"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_expire_at_label"
+            tools:text="2023.07.03" />
+
+        <TextView
+            android:id="@+id/tv_balance_label"
+            style="@style/BEEP.TextStyle.Subtitle1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/gifticon_detail_cash_type_balance_label"
+            app:layout_constraintBottom_toBottomOf="@id/tv_expire_at_label"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tv_expire_at_label"
+            app:layout_constraintTop_toTopOf="@id/tv_expire_at_label" />
+
+        <EditText
+            android:id="@+id/et_balance"
+            style="@style/Theme.BEEP.EditText"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:background="@null"
+            android:enabled="@{vm.mode == mode.EDIT}"
+            android:importantForAutofill="no"
+            android:inputType="number"
+            android:text="@{@string/all_cash_unit(vm.gifticon.balance)}"
+            app:concurrencyFormat="@{vm.gifticon.balance}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@id/tv_balance_label"
+            app:layout_constraintTop_toBottomOf="@id/tv_balance_label"
+            tools:text="3,620원" />
+
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/group_unused"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:constraint_referenced_ids="tv_used_address_label,tv_used_address,tv_used_date_label,tv_used_date,iv_show_all_used_info_button"
+            app:isVisible="@{vm.gifticon.used}"
+            tools:visibility="gone" />
+
+        <TextView
+            android:id="@+id/tv_used_address_label"
+            style="@style/BEEP.TextStyle.Subtitle1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/gifticon_detail_used_address_label"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/et_brand" />
+
+        <TextView
+            android:id="@+id/tv_used_address"
+            style="@style/BEEP.TextStyle.Body1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="@{vm.latestUsageHistory.address}"
+            app:layout_constraintEnd_toStartOf="@id/iv_show_all_used_info_button"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_used_address_label"
+            tools:text="서울시 용산구 백범로 90라길 올리브영" />
+
+        <ImageView
+            android:id="@+id/iv_show_all_used_info_button"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:layout_marginStart="24dp"
+            android:contentDescription="@string/gifticon_detail_show_all_used_info_button_description"
+            android:onClick="@{() -> vm.showAllUsedInfoButtonClicked()}"
+            android:src="@drawable/ic_outline_info"
+            app:layout_constraintBottom_toBottomOf="@id/tv_used_address"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="1"
+            app:layout_constraintStart_toEndOf="@id/tv_used_address"
+            app:layout_constraintTop_toTopOf="@id/tv_used_address"
+            app:tint="@color/gray" />
+
+        <TextView
+            android:id="@+id/tv_used_date_label"
+            style="@style/BEEP.TextStyle.Subtitle1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/gifticon_detail_used_date_label"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_used_address" />
+
+        <TextView
+            android:id="@+id/tv_used_date"
+            style="@style/BEEP.TextStyle.Body1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            app:dateFormat="@{vm.latestUsageHistory.date}"
+            app:layout_constraintStart_toStartOf="@id/tv_used_date_label"
+            app:layout_constraintTop_toBottomOf="@id/tv_used_date_label"
+            tools:text="2022.11.08" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/barrier"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:barrierDirection="bottom"
+            app:constraint_referenced_ids="tv_used_date,tv_expire_at" />
+
+        <EditText
+            android:id="@+id/et_memo"
+            style="@style/Theme.BEEP.EditText"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:background="@drawable/bg_gifticon_detail_memo"
+            android:enabled="@{vm.mode == mode.EDIT}"
+            android:gravity="top"
+            android:hint="@string/gifticon_detail_memo_description"
+            android:importantForAutofill="no"
+            android:inputType="none"
+            android:minHeight="150dp"
+            android:padding="16dp"
+            android:text="@{vm.gifticon.memo}"
+            android:textAppearance="@style/BEEP.TextStyle.Body1"
+            android:textColorHint="#616161"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/barrier"
+            tools:text="adfasdfasdfasdfasdf"
+            tools:visibility="visible" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/src/main/res/layout/fragment_standard_gifticon_info.xml
+++ b/presentation/src/main/res/layout/fragment_standard_gifticon_info.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="vm"
+            type="com.lighthouse.presentation.ui.detailgifticon.GifticonDetailViewModel" />
+
+        <import
+            alias="mode"
+            type="com.lighthouse.presentation.ui.detailgifticon.GifticonDetailMode" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/tv_product_name_label"
+            style="@style/BEEP.TextStyle.Subtitle1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:labelFor="@id/tv_product_name"
+            android:text="@string/gifticon_detail_product_name_label"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <EditText
+            android:id="@+id/tv_product_name"
+            style="@style/Theme.BEEP.EditText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:background="@null"
+            android:ellipsize="end"
+            android:enabled="@{vm.mode == mode.EDIT}"
+            android:importantForAutofill="no"
+            android:inputType="textAutoComplete"
+            android:maxLines="1"
+            android:text="@{vm.gifticon.name}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_product_name_label"
+            tools:text="딸기마카롱설빙" />
+
+        <TextView
+            android:id="@+id/tv_brand_label"
+            style="@style/BEEP.TextStyle.Subtitle1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:labelFor="@id/tv_brand"
+            android:text="@string/gifticon_detail_product_brand_label"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_product_name" />
+
+        <EditText
+            android:id="@+id/et_brand"
+            style="@style/Theme.BEEP.EditText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:background="@null"
+            android:ellipsize="end"
+            android:enabled="@{vm.mode == mode.EDIT}"
+            android:importantForAutofill="no"
+            android:inputType="textAutoComplete"
+            android:maxLines="1"
+            android:text="@{vm.gifticon.brand}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_brand_label"
+            tools:text="설빙" />
+
+        <androidx.constraintlayout.widget.Group
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:constraint_referenced_ids="tv_expire_at_label,tv_expire_at"
+            app:isVisible="@{!vm.gifticon.used}"
+            tools:visibility="gone" />
+
+        <TextView
+            android:id="@+id/tv_expire_at_label"
+            style="@style/BEEP.TextStyle.Subtitle1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/gifticon_detail_product_expire_date_label"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/et_brand" />
+
+        <TextView
+            android:id="@+id/tv_expire_at"
+            style="@style/Theme.BEEP.TextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:enabled="@{vm.mode==mode.EDIT}"
+            android:onClick="@{() -> vm.expireDateClicked()}"
+            app:dateFormat="@{vm.gifticon.expireAt}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_expire_at_label"
+            tools:text="2023.07.03" />
+
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/group_unused"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:constraint_referenced_ids="tv_used_address_label,tv_used_address,tv_used_date_label,tv_used_date"
+            app:isVisible="@{vm.gifticon.used}"
+            tools:visibility="visible" />
+
+        <TextView
+            android:id="@+id/tv_used_address_label"
+            style="@style/BEEP.TextStyle.Subtitle1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/gifticon_detail_used_address_label"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/et_brand" />
+
+        <TextView
+            android:id="@+id/tv_used_address"
+            style="@style/BEEP.TextStyle.Body1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="@{vm.latestUsageHistory.address}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_used_address_label"
+            tools:text="서울시 용산구 백범로 90라길 올리브영" />
+
+        <TextView
+            android:id="@+id/tv_used_date_label"
+            style="@style/BEEP.TextStyle.Subtitle1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/gifticon_detail_used_date_label"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_used_address" />
+
+        <TextView
+            android:id="@+id/tv_used_date"
+            style="@style/BEEP.TextStyle.Body1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            app:dateFormat="@{vm.latestUsageHistory.date}"
+            app:layout_constraintStart_toStartOf="@id/tv_used_date_label"
+            app:layout_constraintTop_toBottomOf="@id/tv_used_date_label"
+            tools:text="2022.11.08" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/barrier"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:barrierDirection="bottom"
+            app:constraint_referenced_ids="tv_used_date,tv_expire_at" />
+
+        <EditText
+            android:id="@+id/et_memo"
+            style="@style/Theme.BEEP.EditText"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:background="@drawable/bg_gifticon_detail_memo"
+            android:enabled="@{vm.mode == mode.EDIT}"
+            android:gravity="top"
+            android:hint="@string/gifticon_detail_memo_description"
+            android:importantForAutofill="no"
+            android:inputType="none"
+            android:minHeight="150dp"
+            android:padding="16dp"
+            android:text="@{vm.gifticon.memo}"
+            android:textAppearance="@style/BEEP.TextStyle.Body1"
+            android:textColorHint="#616161"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/barrier"
+            tools:text="adfasdfasdfasdfasdf"
+            tools:visibility="visible" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>


### PR DESCRIPTION
resolved: #103 

## 작업 내용

- 일반, 금액권 타입 별로 별도의 xml 작성 및 적용
- `LocationConverter` 의 `convertToDD()` 메서드에서 private 키워드 제거 (private 이면 빌드 안 됨)
- 기프티콘 사용 정보 최근 순으로 정렬

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정
