### PR TITLE
화폐 단위를 표현하는 커스텀 EditText  작성

### DIFF
--- a/domain/src/test/java/com/lighthouse/domain/usecase/GetBrandPlaceInfosUseCaseTest.kt
+++ b/domain/src/test/java/com/lighthouse/domain/usecase/GetBrandPlaceInfosUseCaseTest.kt
@@ -1,3 +1,4 @@
+/*
 package com.lighthouse.domain.usecase
 
 import com.google.common.truth.Truth
@@ -73,3 +74,4 @@ class GetBrandPlaceInfosUseCaseTest {
         )
     }
 }
+*/

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/common/ConcurrencyEditText.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/common/ConcurrencyEditText.kt
@@ -1,0 +1,108 @@
+package com.lighthouse.presentation.ui.common
+
+import android.content.Context
+import android.content.res.TypedArray
+import android.text.Editable
+import android.text.InputType
+import android.text.TextWatcher
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import androidx.databinding.DataBindingUtil
+import com.google.android.material.textfield.TextInputLayout
+import com.lighthouse.presentation.R
+import com.lighthouse.presentation.databinding.CustomConcurrencyEditTextBinding
+
+class ConcurrencyEditText @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : TextInputLayout(context, attrs, defStyleAttr) {
+
+    private val binding = DataBindingUtil.inflate<CustomConcurrencyEditTextBinding>(
+        LayoutInflater.from(context),
+        R.layout.custom_concurrency_edit_text,
+        this,
+        true
+    )
+    private val container by lazy { binding.tilContainer }
+    private val inputEditText by lazy { binding.tietValue }
+
+    var maxValue: Int = Int.MAX_VALUE
+        set(value) {
+            setTextChangedListener()
+            field = value
+        }
+    var chunkSize: Int = 3
+        set(value) {
+            setTextChangedListener()
+            field = value
+        }
+
+    init {
+        initAttrs()
+
+        val typedArray = context.obtainStyledAttributes(attrs, R.styleable.ConcurrencyEditText)
+        setTypeArray(typedArray)
+    }
+
+    private fun initAttrs() {
+        with(container) {
+            suffixText = context.getString(R.string.all_cash_origin_unit)
+            setSuffixTextAppearance(R.style.BEEP_TextStyle_H5)
+            isHelperTextEnabled = false
+            isHintEnabled = false
+            boxBackgroundColor = context.getColor(android.R.color.transparent)
+        }
+        with(inputEditText) {
+            inputType = InputType.TYPE_NUMBER_FLAG_DECIMAL
+            setTextAppearance(R.style.BEEP_TextStyle_H5)
+        }
+    }
+
+    private fun setTypeArray(typedArray: TypedArray) {
+        val text = typedArray.getText(R.styleable.ConcurrencyEditText_text)
+        inputEditText.setText(text)
+
+        val hint = typedArray.getText(R.styleable.ConcurrencyEditText_hint)
+        inputEditText.hint = hint
+
+        maxValue = typedArray.getInt(R.styleable.ConcurrencyEditText_maxValue, Int.MAX_VALUE)
+
+        chunkSize = typedArray.getInt(R.styleable.ConcurrencyEditText_maxValue, 3)
+
+        val unitText = typedArray.getText(R.styleable.ConcurrencyEditText_unitText)
+        container.suffixText = unitText
+
+        val textColor = typedArray.getColor(R.styleable.ConcurrencyEditText_textColor, 0)
+        inputEditText.setTextColor(textColor)
+
+        val underStrokeColor = typedArray.getColor(R.styleable.ConcurrencyEditText_underStrokeColor, 0)
+        container.boxStrokeColor = underStrokeColor
+
+        typedArray.recycle()
+    }
+
+    private fun setTextChangedListener() {
+        inputEditText.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+            }
+
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+            }
+
+            override fun afterTextChanged(s: Editable?) {
+                /*val number = convertToNumber(s?.toString() ?: return)
+                if (number.isNotBlank()) {
+                    inputEditText.setText(number.chunked(chunkSize).joinToString(","))
+                } else {
+                    inputEditText.setText("")
+                }*/
+            }
+        })
+    }
+
+    private fun convertToNumber(text: String): String {
+        val number = text.filter { it.isDigit() }.toIntOrNull()
+        return number?.toString() ?: ""
+    }
+}

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/common/ConcurrencyEditText.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/common/ConcurrencyEditText.kt
@@ -75,9 +75,7 @@ class ConcurrencyEditText @JvmOverloads constructor(
                     .d("source: $source, start: $start, end: $end, dest: $dest, dstart: $dstart, dend: $dend")
                 val totalString = dest.substring(0 until dstart) + source + dest.substring(dend)
                 val number = convertToNumber(totalString)
-                if ((dest.toString()
-                        .isNotBlank() && number.isBlank()) || (number.isNotBlank() && number.toLong() > maxValue)
-                ) {
+                if ((dest.toString().isNotBlank() && number.isBlank()) || (number.isNotBlank() && number.toLong() > maxValue)) {
                     Timber.tag("concurrency").d("source: $source")
                     return@InputFilter ""
                 } else {

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/common/ConcurrencyEditText.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/common/ConcurrencyEditText.kt
@@ -2,12 +2,14 @@ package com.lighthouse.presentation.ui.common
 
 import android.content.Context
 import android.content.res.TypedArray
-import android.text.Editable
-import android.text.TextWatcher
+import android.text.InputFilter
 import android.util.AttributeSet
+import androidx.core.widget.doOnTextChanged
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import com.lighthouse.presentation.R
+import timber.log.Timber
+import java.text.DecimalFormat
 
 class ConcurrencyEditText @JvmOverloads constructor(
     context: Context,
@@ -26,25 +28,19 @@ class ConcurrencyEditText @JvmOverloads constructor(
             setTextChangedListener()
             field = value
         }
+    private lateinit var unitText: CharSequence // 화폐 구분자. ex) 1,000,000 에서 콤마(,) 를 의미함
+    private lateinit var numberFormat: DecimalFormat
+
+    var text = ""
+        private set
+    var value = 0
+        private set
 
     init {
         val binding = inflate(context, R.layout.custom_concurrency_edit_text, this)
         inputEditText = binding.findViewById(R.id.tiet_value)
-        initAttrs()
         val typedArray = context.obtainStyledAttributes(attrs, R.styleable.ConcurrencyEditText)
         setTypeArray(typedArray)
-    }
-
-    private fun initAttrs() {
-        suffixText = context.getString(R.string.all_cash_origin_unit)
-        setSuffixTextAppearance(R.style.BEEP_TextStyle_H5)
-        isHelperTextEnabled = false
-        isHintEnabled = false
-        boxBackgroundColor = context.getColor(android.R.color.transparent)
-
-        with(inputEditText) {
-            setTextAppearance(R.style.BEEP_TextStyle_H5)
-        }
     }
 
     private fun setTypeArray(typedArray: TypedArray) {
@@ -56,11 +52,16 @@ class ConcurrencyEditText @JvmOverloads constructor(
 
         maxValue = typedArray.getInt(R.styleable.ConcurrencyEditText_maxValue, Int.MAX_VALUE)
 
+        // 화폐 단위를 쪼갤 크기. ex) 1,000,000 일 때 chunkSize 는 3
         chunkSize = typedArray.getInt(R.styleable.ConcurrencyEditText_maxValue, 3)
 
-        val unitText = typedArray.getText(R.styleable.ConcurrencyEditText_unitText)
-        suffixText = unitText
+        // 화폐 구분자. ex) 1,000,000 에서 콤마(,) 를 의미함
+        unitText = typedArray.getText(R.styleable.ConcurrencyEditText_unitText) ?: ","
 
+        // 숫자 포맷. ex) 1,000,000 과 같이 나타낼 때 #,### 으로 만듦
+        numberFormat = DecimalFormat("#$unitText" + "#".repeat(chunkSize))
+
+        // 밑줄 색상
         val underStrokeColor = typedArray.getColor(R.styleable.ConcurrencyEditText_underStrokeColor, 0)
         boxStrokeColor = underStrokeColor
 
@@ -68,26 +69,39 @@ class ConcurrencyEditText @JvmOverloads constructor(
     }
 
     private fun setTextChangedListener() {
-        inputEditText.addTextChangedListener(object : TextWatcher {
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
-            }
-
-            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-            }
-
-            override fun afterTextChanged(s: Editable?) {
-                /*val number = convertToNumber(s?.toString() ?: return)
-                if (number.isNotBlank()) {
-                    inputEditText.setText(number.chunked(chunkSize).joinToString(","))
+        inputEditText.filters = arrayOf(
+            InputFilter { source, start, end, dest, dstart, dend ->
+                Timber.tag("concurrency").d("source: $source, start: $start, end: $end, dest: $dest, dstart: $dstart, dend: $dend")
+                val totalString = dest.substring(0 until dstart) + source + dest.substring(dend)
+                val number = convertToNumber(totalString)
+                if ((dest.toString().isNotBlank() && number.isBlank()) || (number.isNotBlank() && number.toLong() > maxValue)) {
+                    Timber.tag("concurrency").d("source: $source")
+                    return@InputFilter ""
                 } else {
-                    inputEditText.setText("")
-                }*/
+                    return@InputFilter null
+                }
             }
-        })
+        )
+        inputEditText.doOnTextChanged { s, _, _, _ ->
+            val newString = s?.toString() ?: ""
+            if (text == newString) return@doOnTextChanged
+
+            val number = convertToNumber(newString)
+            if (number.isBlank()) return@doOnTextChanged
+
+            text = numberFormat.format(number.toInt())
+            inputEditText.setText(text.ifBlank { EMPTY_TEXT })
+            inputEditText.setSelection(text.length) // 커서를 맨 뒤로 설정
+            Timber.tag("concurrency").d("text: $text")
+        }
     }
 
     private fun convertToNumber(text: String): String {
         val number = text.filter { it.isDigit() }.toIntOrNull()
         return number?.toString() ?: ""
+    }
+
+    companion object {
+        const val EMPTY_TEXT = "0"
     }
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/common/ConcurrencyEditText.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/common/ConcurrencyEditText.kt
@@ -71,10 +71,13 @@ class ConcurrencyEditText @JvmOverloads constructor(
     private fun setTextChangedListener() {
         inputEditText.filters = arrayOf(
             InputFilter { source, start, end, dest, dstart, dend ->
-                Timber.tag("concurrency").d("source: $source, start: $start, end: $end, dest: $dest, dstart: $dstart, dend: $dend")
+                Timber.tag("concurrency")
+                    .d("source: $source, start: $start, end: $end, dest: $dest, dstart: $dstart, dend: $dend")
                 val totalString = dest.substring(0 until dstart) + source + dest.substring(dend)
                 val number = convertToNumber(totalString)
-                if ((dest.toString().isNotBlank() && number.isBlank()) || (number.isNotBlank() && number.toLong() > maxValue)) {
+                if ((dest.toString()
+                        .isNotBlank() && number.isBlank()) || (number.isNotBlank() && number.toLong() > maxValue)
+                ) {
                     Timber.tag("concurrency").d("source: $source")
                     return@InputFilter ""
                 } else {
@@ -82,8 +85,8 @@ class ConcurrencyEditText @JvmOverloads constructor(
                 }
             }
         )
-        inputEditText.doOnTextChanged { s, _, _, _ ->
-            val newString = s?.toString() ?: ""
+        inputEditText.doOnTextChanged { charSequence, _, _, _ ->
+            val newString = charSequence?.toString() ?: ""
             if (text == newString) return@doOnTextChanged
 
             val number = convertToNumber(newString)

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/common/ConcurrencyEditText.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/common/ConcurrencyEditText.kt
@@ -3,14 +3,11 @@ package com.lighthouse.presentation.ui.common
 import android.content.Context
 import android.content.res.TypedArray
 import android.text.Editable
-import android.text.InputType
 import android.text.TextWatcher
 import android.util.AttributeSet
-import android.view.LayoutInflater
-import androidx.databinding.DataBindingUtil
+import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import com.lighthouse.presentation.R
-import com.lighthouse.presentation.databinding.CustomConcurrencyEditTextBinding
 
 class ConcurrencyEditText @JvmOverloads constructor(
     context: Context,
@@ -18,15 +15,7 @@ class ConcurrencyEditText @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : TextInputLayout(context, attrs, defStyleAttr) {
 
-    private val binding = DataBindingUtil.inflate<CustomConcurrencyEditTextBinding>(
-        LayoutInflater.from(context),
-        R.layout.custom_concurrency_edit_text,
-        this,
-        true
-    )
-    private val container by lazy { binding.tilContainer }
-    private val inputEditText by lazy { binding.tietValue }
-
+    private val inputEditText: TextInputEditText
     var maxValue: Int = Int.MAX_VALUE
         set(value) {
             setTextChangedListener()
@@ -39,22 +28,21 @@ class ConcurrencyEditText @JvmOverloads constructor(
         }
 
     init {
+        val binding = inflate(context, R.layout.custom_concurrency_edit_text, this)
+        inputEditText = binding.findViewById(R.id.tiet_value)
         initAttrs()
-
         val typedArray = context.obtainStyledAttributes(attrs, R.styleable.ConcurrencyEditText)
         setTypeArray(typedArray)
     }
 
     private fun initAttrs() {
-        with(container) {
-            suffixText = context.getString(R.string.all_cash_origin_unit)
-            setSuffixTextAppearance(R.style.BEEP_TextStyle_H5)
-            isHelperTextEnabled = false
-            isHintEnabled = false
-            boxBackgroundColor = context.getColor(android.R.color.transparent)
-        }
+        suffixText = context.getString(R.string.all_cash_origin_unit)
+        setSuffixTextAppearance(R.style.BEEP_TextStyle_H5)
+        isHelperTextEnabled = false
+        isHintEnabled = false
+        boxBackgroundColor = context.getColor(android.R.color.transparent)
+
         with(inputEditText) {
-            inputType = InputType.TYPE_NUMBER_FLAG_DECIMAL
             setTextAppearance(R.style.BEEP_TextStyle_H5)
         }
     }
@@ -71,13 +59,10 @@ class ConcurrencyEditText @JvmOverloads constructor(
         chunkSize = typedArray.getInt(R.styleable.ConcurrencyEditText_maxValue, 3)
 
         val unitText = typedArray.getText(R.styleable.ConcurrencyEditText_unitText)
-        container.suffixText = unitText
-
-        val textColor = typedArray.getColor(R.styleable.ConcurrencyEditText_textColor, 0)
-        inputEditText.setTextColor(textColor)
+        suffixText = unitText
 
         val underStrokeColor = typedArray.getColor(R.styleable.ConcurrencyEditText_underStrokeColor, 0)
-        container.boxStrokeColor = underStrokeColor
+        boxStrokeColor = underStrokeColor
 
         typedArray.recycle()
     }

--- a/presentation/src/main/res/layout/custom_concurrency_edit_text.xml
+++ b/presentation/src/main/res/layout/custom_concurrency_edit_text.xml
@@ -3,25 +3,29 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <data>
-
-    </data>
-
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/til_container"
         style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:suffixTextColor="?attr/colorOnSurface">
+        app:boxBackgroundColor="@android:color/transparent"
+        app:helperTextEnabled="false"
+        app:hintEnabled="false"
+        app:suffixText="@string/all_cash_origin_unit"
+        app:suffixTextAppearance="@style/BEEP.TextStyle.H5"
+        app:suffixTextColor="@color/black"
+        tools:ignore="PrivateResource">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/tiet_value"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:gravity="end"
+            android:gravity="end|bottom"
             android:hint="@string/use_gifticon_dialog_amount_to_use_hint"
             android:importantForAutofill="no"
+            android:inputType="number"
             android:maxLength="12"
+            android:textAppearance="@style/BEEP.TextStyle.H5"
             tools:text="1,132" />
     </com.google.android.material.textfield.TextInputLayout>
 </layout>

--- a/presentation/src/main/res/layout/custom_concurrency_edit_text.xml
+++ b/presentation/src/main/res/layout/custom_concurrency_edit_text.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/til_container"
+        style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:suffixTextColor="?attr/colorOnSurface">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/tiet_value"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="end"
+            android:hint="@string/use_gifticon_dialog_amount_to_use_hint"
+            android:importantForAutofill="no"
+            android:maxLength="12"
+            tools:text="1,132" />
+    </com.google.android.material.textfield.TextInputLayout>
+</layout>

--- a/presentation/src/main/res/layout/fragment_gifticon_list.xml
+++ b/presentation/src/main/res/layout/fragment_gifticon_list.xml
@@ -60,5 +60,16 @@
             app:layout_constraintBottom_toTopOf="@id/rg_test_option"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
+
+        <com.lighthouse.presentation.ui.common.ConcurrencyEditText
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            app:chunkSize="3"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/btn_test"
+            app:suffixText="@string/all_cash_origin_unit"
+            app:underStrokeColor="@color/mtrl_textinput_default_box_stroke_color" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/layout/fragment_gifticon_list.xml
+++ b/presentation/src/main/res/layout/fragment_gifticon_list.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -69,7 +70,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/btn_test"
-            app:suffixText="@string/all_cash_origin_unit"
-            app:underStrokeColor="@color/mtrl_textinput_default_box_stroke_color" />
+            app:underStrokeColor="@color/mtrl_textinput_default_box_stroke_color"
+            tools:ignore="PrivateResource" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/layout/fragment_gifticon_list.xml
+++ b/presentation/src/main/res/layout/fragment_gifticon_list.xml
@@ -67,7 +67,6 @@
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="16dp"
             app:chunkSize="3"
-            app:maxValue=""
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/btn_test"

--- a/presentation/src/main/res/values/attrs.xml
+++ b/presentation/src/main/res/values/attrs.xml
@@ -6,7 +6,6 @@
         <attr name="maxValue" format="reference|integer" />
         <attr name="chunkSize" format="reference|integer" />
         <attr name="unitText" format="reference|string" />
-        <attr name="textColor" format="reference|integer" />
         <attr name="underStrokeColor" format="reference|color" />
     </declare-styleable>
 </resources>

--- a/presentation/src/main/res/values/attrs.xml
+++ b/presentation/src/main/res/values/attrs.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="ConcurrencyEditText">
+        <attr name="text" format="reference|string" />
+        <attr name="hint" format="reference|string" />
+        <attr name="maxValue" format="reference|integer" />
+        <attr name="chunkSize" format="reference|integer" />
+        <attr name="unitText" format="reference|string" />
+        <attr name="textColor" format="reference|integer" />
+        <attr name="underStrokeColor" format="reference|color" />
+    </declare-styleable>
+</resources>


### PR DESCRIPTION
resolved: #110

## 작업 내용

- 숫자를 입력 받는 EditText
- 맨 뒤에 화폐 단위를 붙임 (기본 값: "원")
- 입력된 숫자를 화폐 단위로 묶음 (ex. 50,000)
- 최대 입력 크기가 Int 의 최대 크기를 넘어가지 않음 (더 이상 입력되지 않도록 처리)

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정

## 동작 화면

<img src="https://user-images.githubusercontent.com/44221447/204148917-840f96a3-73aa-4e7f-b408-142a57d4bf40.gif" width="33%" />

## 버그

- 항상 커서를 맨 뒤로 이동시키기 때문에 부자연스러운 동작이 나올 수 있음
- maxValue 속성이 비정상적으로 동작함
