### PR TITLE
기프티콘 추가 UI 작업 마무리

### DIFF
--- a/presentation/src/main/java/com/lighthouse/presentation/binding/EditText.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/binding/EditText.kt
@@ -1,0 +1,12 @@
+package com.lighthouse.presentation.binding
+
+import android.widget.EditText
+import androidx.databinding.BindingAdapter
+import com.lighthouse.presentation.model.EditTextInfo
+
+@BindingAdapter("setEditTextInfo")
+fun setEditTextInfo(editText: EditText, info: EditTextInfo?) {
+    info ?: return
+    editText.setText(info.text)
+    editText.setSelection(info.selection)
+}

--- a/presentation/src/main/java/com/lighthouse/presentation/extension/KotlinExtention.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/extension/KotlinExtention.kt
@@ -29,6 +29,10 @@ val screenWidth: Int
 val screenHeight: Int
     get() = Resources.getSystem().displayMetrics?.heightPixels ?: 0
 
+fun String.toDigit(): Int {
+    return filter { it.isDigit() }.toIntOrNull() ?: 0
+}
+
 fun Date.toYear(): Int {
     val calendar = Calendar.getInstance()
     calendar.time = this

--- a/presentation/src/main/java/com/lighthouse/presentation/mapper/AddGifticonUIModelMapper.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/mapper/AddGifticonUIModelMapper.kt
@@ -29,8 +29,7 @@ fun GalleryUIModel.Gallery.toAddGifticonUIModel(
     isCashCard: Boolean = false,
     balance: String = "",
     memo: String = "",
-    thumbnailImage: CroppedImage = CroppedImage(),
-    brandImage: CroppedImage = CroppedImage()
+    thumbnailImage: CroppedImage = CroppedImage()
 ): AddGifticonUIModel {
     return AddGifticonUIModel(
         id = id,
@@ -42,7 +41,6 @@ fun GalleryUIModel.Gallery.toAddGifticonUIModel(
         isCashCard = isCashCard,
         balance = EditTextInfo(balance, balance.length),
         memo = memo,
-        thumbnailImage = thumbnailImage,
-        brandImage = brandImage
+        thumbnailImage = thumbnailImage
     )
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/mapper/AddGifticonUIModelMapper.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/mapper/AddGifticonUIModelMapper.kt
@@ -2,6 +2,7 @@ package com.lighthouse.presentation.mapper
 
 import com.lighthouse.presentation.model.AddGifticonUIModel
 import com.lighthouse.presentation.model.CroppedImage
+import com.lighthouse.presentation.model.EditTextInfo
 import com.lighthouse.presentation.model.GalleryUIModel
 import com.lighthouse.presentation.ui.addgifticon.adapter.AddGifticonItemUIModel
 import java.util.Date
@@ -36,10 +37,10 @@ fun GalleryUIModel.Gallery.toAddGifticonUIModel(
         origin = uri,
         name = name,
         brandName = brandName,
-        barcode = barcode,
+        barcode = EditTextInfo(barcode, barcode.length),
         expiredAt = expiredAt,
         isCashCard = isCashCard,
-        balance = balance,
+        balance = EditTextInfo(balance, balance.length),
         memo = memo,
         thumbnailImage = thumbnailImage,
         brandImage = brandImage

--- a/presentation/src/main/java/com/lighthouse/presentation/model/AddGifticonUIModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/model/AddGifticonUIModel.kt
@@ -13,7 +13,6 @@ data class AddGifticonUIModel(
     val isCashCard: Boolean,
     val balance: EditTextInfo,
     val memo: String,
-    val brandImage: CroppedImage,
     val thumbnailImage: CroppedImage
 ) {
     val uri: Uri

--- a/presentation/src/main/java/com/lighthouse/presentation/model/AddGifticonUIModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/model/AddGifticonUIModel.kt
@@ -8,10 +8,10 @@ data class AddGifticonUIModel(
     val origin: Uri,
     val name: String,
     val brandName: String,
-    val barcode: String,
+    val barcode: EditTextInfo,
     val expiredAt: Date,
     val isCashCard: Boolean,
-    val balance: String,
+    val balance: EditTextInfo,
     val memo: String,
     val brandImage: CroppedImage,
     val thumbnailImage: CroppedImage

--- a/presentation/src/main/java/com/lighthouse/presentation/model/EditTextInfo.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/model/EditTextInfo.kt
@@ -1,0 +1,6 @@
+package com.lighthouse.presentation.model
+
+data class EditTextInfo(
+    val text: String,
+    val selection: Int
+)

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonActivity.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonActivity.kt
@@ -8,6 +8,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.inputmethod.InputMethodManager
 import androidx.activity.addCallback
+import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -22,6 +23,7 @@ import com.lighthouse.presentation.extension.getParcelable
 import com.lighthouse.presentation.extension.getParcelableArrayList
 import com.lighthouse.presentation.extension.repeatOnStarted
 import com.lighthouse.presentation.extra.Extras
+import com.lighthouse.presentation.model.CroppedImage
 import com.lighthouse.presentation.model.GalleryUIModel
 import com.lighthouse.presentation.ui.addgifticon.adapter.AddGifticonAdapter
 import com.lighthouse.presentation.ui.addgifticon.dialog.OriginImageDialog
@@ -35,6 +37,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.util.Calendar
@@ -70,25 +73,31 @@ class AddGifticonActivity : AppCompatActivity() {
         }
     }
 
-    private val cropGifticon = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-        if (result.resultCode == Activity.RESULT_OK) {
-            val croppedUri =
-                result.data?.getParcelable(Extras.KEY_CROPPED_IMAGE, Uri::class.java)
-                    ?: return@registerForActivityResult
-            val croppedRect = result.data?.getParcelable(Extras.KEY_CROPPED_RECT, RectF::class.java)
-                ?: return@registerForActivityResult
+    private suspend fun getCropResult(result: ActivityResult, output: File): CroppedImage? {
+        return if (result.resultCode == Activity.RESULT_OK) {
+            val croppedUri = result.data?.getParcelable(Extras.KEY_CROPPED_IMAGE, Uri::class.java) ?: return null
+            val croppedRect = result.data?.getParcelable(Extras.KEY_CROPPED_RECT, RectF::class.java) ?: return null
 
-            val gifticon = viewModel.selectedGifticon.value ?: return@registerForActivityResult
-            val output = getFileStreamPath("Temp${gifticon.id}")
-
-            lifecycleScope.launch {
-                withContext(Dispatchers.IO) {
-                    FileInputStream(croppedUri.path).copyTo(
-                        FileOutputStream(output)
-                    )
-                }
-                viewModel.croppedImage(output.toUri(), croppedRect)
+            withContext(Dispatchers.IO) {
+                FileInputStream(croppedUri.path).copyTo(
+                    FileOutputStream(output)
+                )
             }
+            CroppedImage(output.toUri(), croppedRect)
+        } else {
+            null
+        }
+    }
+
+    private val cropGifticon = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+        val gifticon = viewModel.selectedGifticon.value ?: return@registerForActivityResult
+        val output = getFileStreamPath("$TEMP_GIFTICON_PREFIX${gifticon.id}")
+
+        lifecycleScope.launch {
+            val croppedImage = withContext(Dispatchers.IO) {
+                getCropResult(result, output)
+            } ?: return@launch
+            viewModel.croppedGifticonImage(croppedImage)
         }
     }
 
@@ -219,5 +228,9 @@ class AddGifticonActivity : AppCompatActivity() {
 
     private fun showSnackBar(uiText: UIText) {
         Snackbar.make(binding.root, uiText.asString(applicationContext), Snackbar.LENGTH_SHORT).show()
+    }
+
+    companion object {
+        private const val TEMP_GIFTICON_PREFIX = "temp_gifticon_"
     }
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonActivity.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonActivity.kt
@@ -1,10 +1,12 @@
 package com.lighthouse.presentation.ui.addgifticon
 
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import android.graphics.RectF
 import android.net.Uri
 import android.os.Bundle
+import android.view.inputmethod.InputMethodManager
 import androidx.activity.addCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
@@ -198,14 +200,20 @@ class AddGifticonActivity : AppCompatActivity() {
     }
 
     private fun requestFocus(focus: AddGifticonFocus) {
-        when (focus) {
-            AddGifticonFocus.GIFTICON_NAME -> binding.tietName.requestFocus()
-            AddGifticonFocus.BRAND_NAME -> binding.tietBrand.requestFocus()
-            AddGifticonFocus.BARCODE -> binding.tietBarcode.requestFocus()
-            AddGifticonFocus.EXPIRED_AT -> binding.tietExpireDate.requestFocus()
-            AddGifticonFocus.BALANCE -> binding.tietBalance.requestFocus()
-            AddGifticonFocus.MEMO -> binding.tietMemo.requestFocus()
-            AddGifticonFocus.NONE -> binding.clContainer.requestFocus()
+        val focusView = when (focus) {
+            AddGifticonFocus.GIFTICON_NAME -> binding.tietName
+            AddGifticonFocus.BRAND_NAME -> binding.tietBrand
+            AddGifticonFocus.BARCODE -> binding.tietBarcode
+            AddGifticonFocus.BALANCE -> binding.tietBalance
+            AddGifticonFocus.MEMO -> binding.tietMemo
+            AddGifticonFocus.NONE -> binding.clContainer
+        }
+        focusView.requestFocus()
+        val inputMethodService = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        if (focus != AddGifticonFocus.NONE) {
+            inputMethodService.showSoftInput(focusView, 0)
+        } else {
+            inputMethodService.hideSoftInputFromWindow(currentFocus?.windowToken, InputMethodManager.HIDE_NOT_ALWAYS)
         }
     }
 

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonEvent.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonEvent.kt
@@ -9,7 +9,7 @@ sealed class AddGifticonEvent {
 
     object PopupBackStack : AddGifticonEvent()
     object ShowConfirmation : AddGifticonEvent()
-    data class NavigateToGallery(val list: List<Long>) : AddGifticonEvent()
+    data class NavigateToGallery(val list: List<Long> = emptyList()) : AddGifticonEvent()
     data class NavigateToCropGifticon(val origin: Uri, val croppedRect: RectF) : AddGifticonEvent()
     data class ShowOriginGifticon(val origin: Uri) : AddGifticonEvent()
     data class ShowExpiredAtDatePicker(val date: Date) : AddGifticonEvent()

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonFocus.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonFocus.kt
@@ -4,7 +4,6 @@ enum class AddGifticonFocus {
     GIFTICON_NAME,
     BRAND_NAME,
     BARCODE,
-    EXPIRED_AT,
     BALANCE,
     MEMO,
     NONE

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonValid.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonValid.kt
@@ -21,7 +21,7 @@ enum class AddGifticonValid(val focus: AddGifticonFocus, val text: UIText) {
         UIText.StringResource(R.string.add_gifticon_invalid_barcode)
     ),
     INVALID_EXPIRED_AT(
-        AddGifticonFocus.EXPIRED_AT,
+        AddGifticonFocus.NONE,
         UIText.StringResource(R.string.add_gifticon_invalid_expired_at)
     ),
     INVALID_BALANCE(

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonViewModel.kt
@@ -1,7 +1,5 @@
 package com.lighthouse.presentation.ui.addgifticon
 
-import android.graphics.RectF
-import android.net.Uri
 import android.text.InputFilter
 import android.view.inputmethod.EditorInfo
 import androidx.lifecycle.ViewModel
@@ -27,7 +25,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.text.DecimalFormat
 import java.util.Calendar
@@ -220,14 +217,9 @@ class AddGifticonViewModel : ViewModel() {
         return false
     }
 
-    fun croppedImage(uri: Uri, rect: RectF) {
-        val image = CroppedImage(uri, rect)
-        updateSelectedDisplayGifticon { it.copy(thumbnailImage = image) }
-        updateSelectedGifticon { it.copy(thumbnailImage = image) }
-    }
-
-    fun croppedBrandImage(uri: Uri, rect: RectF) {
-        updateSelectedGifticon { it.copy(brandImage = CroppedImage(uri, rect)) }
+    fun croppedGifticonImage(croppedImage: CroppedImage) {
+        updateSelectedDisplayGifticon { it.copy(thumbnailImage = croppedImage) }
+        updateSelectedGifticon { it.copy(thumbnailImage = croppedImage) }
     }
 
     fun changeCashCard(checked: Boolean) {

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonViewModel.kt
@@ -157,9 +157,12 @@ class AddGifticonViewModel : ViewModel() {
         }
     }
 
-    private fun updateSelectedDisplayGifticon(update: (AddGifticonItemUIModel.Gifticon) -> AddGifticonItemUIModel.Gifticon) {
+    private fun updateSelectedDisplayGifticon(
+        srcIndex: Long? = selectedId.value,
+        update: (AddGifticonItemUIModel.Gifticon) -> AddGifticonItemUIModel.Gifticon
+    ) {
         val index = displayList.value.indexOfFirst {
-            it is AddGifticonItemUIModel.Gifticon && it.id == selectedId.value
+            it is AddGifticonItemUIModel.Gifticon && it.id == srcIndex
         }
         if (index == -1) {
             return
@@ -173,19 +176,23 @@ class AddGifticonViewModel : ViewModel() {
         _displayList.value = oldList.subList(0, index) + listOf(newItem) + oldList.subList(index + 1, oldList.size)
     }
 
-    private fun updateSelectedGifticon(update: (AddGifticonUIModel) -> AddGifticonUIModel) {
-        val index = gifticonList.value.indexOfFirst { it.id == selectedId.value }
+    private fun updateSelectedGifticon(
+        srcIndex: Long? = selectedId.value,
+        update: (AddGifticonUIModel) -> AddGifticonUIModel
+    ): AddGifticonUIModel? {
+        val index = gifticonList.value.indexOfFirst { it.id == srcIndex }
         if (index == -1) {
-            return
+            return null
         }
         val oldList = gifticonList.value
         val oldItem = oldList[index]
         val newItem = update(oldItem)
         if (oldItem == newItem) {
-            return
+            return null
         }
         gifticonList.value =
             oldList.subList(0, index) + listOf(newItem) + oldList.subList(index + 1, oldList.size)
+        return newItem
     }
 
     fun croppedImage(uri: Uri, rect: RectF) {
@@ -199,23 +206,38 @@ class AddGifticonViewModel : ViewModel() {
     }
 
     fun changeCashCard(checked: Boolean) {
-        updateSelectedGifticon { it.copy(isCashCard = checked) }
+        val updated = updateSelectedGifticon { it.copy(isCashCard = checked) }
+        if (updated != null) {
+            updateSelectedDisplayGifticon { it.copy(isValid = checkGifticonValid(updated) == AddGifticonValid.VALID) }
+        }
     }
 
     fun changeGifticonName(name: CharSequence) {
-        updateSelectedGifticon { it.copy(name = name.toString()) }
+        val updated = updateSelectedGifticon { it.copy(name = name.toString()) }
+        if (updated != null) {
+            updateSelectedDisplayGifticon { it.copy(isValid = checkGifticonValid(updated) == AddGifticonValid.VALID) }
+        }
     }
 
     fun changeBrandName(brandName: CharSequence) {
-        updateSelectedGifticon { it.copy(brandName = brandName.toString()) }
+        val updated = updateSelectedGifticon { it.copy(brandName = brandName.toString()) }
+        if (updated != null) {
+            updateSelectedDisplayGifticon { it.copy(isValid = checkGifticonValid(updated) == AddGifticonValid.VALID) }
+        }
     }
 
     fun changeBarcode(barcode: CharSequence) {
-        updateSelectedGifticon { it.copy(barcode = barcode.toString()) }
+        val updated = updateSelectedGifticon { it.copy(barcode = barcode.toString()) }
+        if (updated != null) {
+            updateSelectedDisplayGifticon { it.copy(isValid = checkGifticonValid(updated) == AddGifticonValid.VALID) }
+        }
     }
 
     fun changeExpiredAt(expiredAt: Date) {
-        updateSelectedGifticon { it.copy(expiredAt = expiredAt) }
+        val updated = updateSelectedGifticon { it.copy(expiredAt = expiredAt) }
+        if (updated != null) {
+            updateSelectedDisplayGifticon { it.copy(isValid = checkGifticonValid(updated) == AddGifticonValid.VALID) }
+        }
     }
 
     val balanceFilters = arrayOf(
@@ -252,7 +274,10 @@ class AddGifticonViewModel : ViewModel() {
         }
 
         val newText = balanceFormat.format(newValueText.toDigit())
-        updateSelectedGifticon { it.copy(balance = newText) }
+        val updated = updateSelectedGifticon { it.copy(balance = newText) }
+        if (updated != null) {
+            updateSelectedDisplayGifticon { it.copy(isValid = checkGifticonValid(updated) == AddGifticonValid.VALID) }
+        }
 
         balanceSelection.value = if (oldBalance.length == start) {
             newText.length

--- a/presentation/src/main/res/color/on_surface_12.xml
+++ b/presentation/src/main/res/color/on_surface_12.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:alpha="0.12"
+        android:color="?attr/colorOnSurface"/>
+</selector>

--- a/presentation/src/main/res/color/on_surface_9.xml
+++ b/presentation/src/main/res/color/on_surface_9.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:alpha="0.09"
+        android:color="?attr/colorOnSurface"/>
+</selector>

--- a/presentation/src/main/res/drawable/bg_gifticon_memo.xml
+++ b/presentation/src/main/res/drawable/bg_gifticon_memo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
     <corners android:radius="8dp" />
-    <solid android:color="@color/light_gray" />
+    <solid android:color="@color/on_surface_12" />
 </shape>

--- a/presentation/src/main/res/layout/activity_add_gifticon.xml
+++ b/presentation/src/main/res/layout/activity_add_gifticon.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
@@ -121,7 +122,8 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_registered"
-                    app:setItems="@{vm.displayList}" />
+                    app:setItems="@{vm.displayList}"
+                    tools:listitem="@layout/item_add_goto_gallery" />
 
                 <ImageView
                     android:id="@+id/iv_gifticon_image"
@@ -156,14 +158,13 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
-                    android:background="@color/gray"
+                    android:background="@color/on_surface_12"
                     android:enabled="@{vm.isSelected}"
                     android:gravity="center"
                     android:onClick="@{() -> vm.showOriginGifticon()}"
                     android:padding="12dp"
                     android:text="@string/add_gifticon_confirm_origin_image"
                     android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
-                    android:textColor="@color/white"
                     android:textStyle="bold"
                     app:layout_constraintEnd_toEndOf="@id/guideline_end"
                     app:layout_constraintStart_toStartOf="@id/guideline_start"
@@ -299,8 +300,8 @@
                         android:lines="1"
                         android:maxLength="19"
                         android:onTextChanged="@{(text, start, end, count) -> vm.changeBarcode(text, start, end, count)}"
-                        app:setEditTextInfo="@{vm.barcode}"
-                        app:onEditorActionListener="@{(view, actionId, event) -> vm.onActionNextListener(actionId)}" />
+                        app:onEditorActionListener="@{(view, actionId, event) -> vm.onActionNextListener(actionId)}"
+                        app:setEditTextInfo="@{vm.barcode}" />
 
                 </com.google.android.material.textfield.TextInputLayout>
 
@@ -343,8 +344,8 @@
                         android:inputType="number"
                         android:lines="1"
                         android:onTextChanged="@{(text, start, end, count) -> vm.changeBalance(text, start, end, count)}"
-                        app:setEditTextInfo="@{vm.balance}"
-                        app:onEditorActionListener="@{(view, actionId, event) -> vm.onActionNextListener(actionId)}" />
+                        app:onEditorActionListener="@{(view, actionId, event) -> vm.onActionNextListener(actionId)}"
+                        app:setEditTextInfo="@{vm.balance}" />
 
                 </com.google.android.material.textfield.TextInputLayout>
 
@@ -398,11 +399,12 @@
 
                 <com.google.android.material.textfield.TextInputLayout
                     android:id="@+id/til_memo"
-                    style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:background="@drawable/bg_gifticon_memo"
                     android:enabled="@{vm.isSelected}"
-                    app:boxBackgroundColor="@null"
+                    app:boxBackgroundMode="none"
                     app:endIconMode="clear_text"
                     app:hintEnabled="false"
                     app:layout_constraintEnd_toEndOf="@id/guideline_end"
@@ -415,6 +417,8 @@
                         android:layout_height="wrap_content"
                         android:hint="@string/add_gifticon_memo_hint"
                         android:inputType="textNoSuggestions|textMultiLine"
+                        android:minHeight="80dp"
+                        android:gravity="top"
                         android:onTextChanged="@{(text, start, end, count) -> vm.changeMemo(text)}"
                         android:text="@{vm.memo}" />
 

--- a/presentation/src/main/res/layout/activity_add_gifticon.xml
+++ b/presentation/src/main/res/layout/activity_add_gifticon.xml
@@ -381,12 +381,13 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:hint="@string/add_gifticon_balance_hint"
-                        android:imeOptions="actionNext"
                         android:inputType="number"
+                        android:imeOptions="actionNext"
                         android:lines="1"
-                        android:maxLength="7"
-                        android:onTextChanged="@{(text, start, end, count) -> vm.changeBalance(text)}"
-                        android:text="@{vm.balance}" />
+                        android:filters="@{vm.balanceFilters}"
+                        android:onTextChanged="@{(text, start, end, count) -> vm.changeBalance(text, start, end, count)}"
+                        android:text="@{vm.balance}"
+                        android:selection="@{vm.balanceSelection}"/>
 
                 </com.google.android.material.textfield.TextInputLayout>
 

--- a/presentation/src/main/res/layout/activity_add_gifticon.xml
+++ b/presentation/src/main/res/layout/activity_add_gifticon.xml
@@ -194,6 +194,7 @@
                     android:layout_height="wrap_content"
                     android:checked="@{vm.isCashCard}"
                     android:enabled="@{vm.isSelected}"
+                    android:onClick="@{() -> vm.requestCashCard()}"
                     app:layout_constraintBottom_toBottomOf="@id/iv_brand"
                     app:layout_constraintEnd_toEndOf="@id/guideline_end"
                     app:layout_constraintTop_toTopOf="@id/iv_brand"
@@ -324,10 +325,8 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     app:boxBackgroundColor="@null"
-                    app:endIconCheckable="true"
                     app:endIconDrawable="@drawable/ic_add_gifticon_calendar"
                     app:endIconMode="custom"
-                    app:endIconOnClickListener="@{() -> vm.showExpiredAtDatePicker()}"
                     app:hintEnabled="false"
                     android:enabled="@{vm.isSelected}"
                     app:layout_constraintEnd_toEndOf="@id/guideline_end"
@@ -338,10 +337,13 @@
                         android:id="@+id/tiet_expire_date"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:focusable="false"
+                        android:cursorVisible="false"
                         android:hint="@string/add_gifticon_expire_date_hint"
-                        android:imeOptions="actionNext"
-                        android:inputType="date"
-                        android:lines="1" />
+                        android:inputType="none"
+                        android:lines="1"
+                        android:onClick="@{() -> vm.showExpiredAtDatePicker()}"
+                        app:setUIText="@{vm.expiredAt}"/>
 
                 </com.google.android.material.textfield.TextInputLayout>
 

--- a/presentation/src/main/res/layout/activity_add_gifticon.xml
+++ b/presentation/src/main/res/layout/activity_add_gifticon.xml
@@ -169,15 +169,6 @@
                     app:layout_constraintStart_toStartOf="@id/guideline_start"
                     app:layout_constraintTop_toBottomOf="@id/iv_gifticon_image" />
 
-                <ImageView
-                    android:id="@+id/iv_brand"
-                    android:layout_width="36dp"
-                    android:layout_height="36dp"
-                    android:layout_marginTop="16dp"
-                    android:contentDescription="@string/add_gifticon_brand_description"
-                    app:layout_constraintStart_toStartOf="@id/guideline_start"
-                    app:layout_constraintTop_toBottomOf="@id/tv_origin_image" />
-
                 <TextView
                     android:id="@+id/tv_cash_card"
                     android:layout_width="wrap_content"
@@ -192,13 +183,13 @@
                 <com.google.android.material.switchmaterial.SwitchMaterial
                     android:id="@+id/switch_cash_card"
                     android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
+                    android:layout_height="36dp"
+                    android:layout_marginTop="16dp"
                     android:checked="@{vm.isCashCard}"
                     android:enabled="@{vm.isSelected}"
                     android:onClick="@{() -> vm.requestCashCard()}"
-                    app:layout_constraintBottom_toBottomOf="@id/iv_brand"
                     app:layout_constraintEnd_toEndOf="@id/guideline_end"
-                    app:layout_constraintTop_toTopOf="@id/iv_brand"
+                    app:layout_constraintTop_toBottomOf="@id/tv_origin_image"
                     app:onCheckedChangeListener="@{(view, checked) -> vm.changeCashCard(checked)}" />
 
                 <TextView
@@ -209,7 +200,7 @@
                     android:text="@string/add_gifticon_name_label"
                     android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
                     app:layout_constraintStart_toStartOf="@id/guideline_start"
-                    app:layout_constraintTop_toBottomOf="@id/iv_brand" />
+                    app:layout_constraintTop_toBottomOf="@id/switch_cash_card" />
 
                 <com.google.android.material.textfield.TextInputLayout
                     android:id="@+id/til_name"

--- a/presentation/src/main/res/layout/activity_add_gifticon.xml
+++ b/presentation/src/main/res/layout/activity_add_gifticon.xml
@@ -233,7 +233,8 @@
                         android:inputType="textNoSuggestions"
                         android:lines="1"
                         android:onTextChanged="@{(text, start, end, count) -> vm.changeGifticonName(text)}"
-                        android:text="@{vm.name}" />
+                        android:text="@{vm.name}"
+                        app:onEditorActionListener="@{(view, actionId, event) -> vm.onActionNextListener(actionId)}" />
 
                 </com.google.android.material.textfield.TextInputLayout>
 
@@ -269,7 +270,8 @@
                         android:inputType="textNoSuggestions"
                         android:lines="1"
                         android:onTextChanged="@{(text, start, end, count) -> vm.changeBrandName(text)}"
-                        android:text="@{vm.brand}" />
+                        android:text="@{vm.brand}"
+                        app:onEditorActionListener="@{(view, actionId, event) -> vm.onActionNextListener(actionId)}" />
 
                 </com.google.android.material.textfield.TextInputLayout>
 
@@ -306,8 +308,8 @@
                         android:lines="1"
                         android:maxLength="19"
                         android:onTextChanged="@{(text, start, end, count) -> vm.changeBarcode(text, start, end, count)}"
-                        android:selection="@{vm.barcodeSelection}"
-                        android:text="@{vm.barcode}" />
+                        app:setEditTextInfo="@{vm.barcode}"
+                        app:onEditorActionListener="@{(view, actionId, event) -> vm.onActionNextListener(actionId)}" />
 
                 </com.google.android.material.textfield.TextInputLayout>
 
@@ -350,8 +352,8 @@
                         android:inputType="number"
                         android:lines="1"
                         android:onTextChanged="@{(text, start, end, count) -> vm.changeBalance(text, start, end, count)}"
-                        android:selection="@{vm.balanceSelection}"
-                        android:text="@{vm.balance}" />
+                        app:setEditTextInfo="@{vm.balance}"
+                        app:onEditorActionListener="@{(view, actionId, event) -> vm.onActionNextListener(actionId)}" />
 
                 </com.google.android.material.textfield.TextInputLayout>
 
@@ -363,7 +365,7 @@
                     android:text="@string/add_gifticon_expire_date_label"
                     android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
                     app:layout_constraintStart_toStartOf="@id/guideline_start"
-                    app:layout_constraintTop_toBottomOf="@id/tv_balance" />
+                    app:layout_constraintTop_toBottomOf="@id/til_balance" />
 
                 <com.google.android.material.textfield.TextInputLayout
                     android:id="@+id/til_expire_date"

--- a/presentation/src/main/res/layout/activity_add_gifticon.xml
+++ b/presentation/src/main/res/layout/activity_add_gifticon.xml
@@ -66,7 +66,8 @@
         <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior">
+            app:layout_behavior="@string/appbar_scrolling_view_behavior"
+            app:layout_dodgeInsetEdges="bottom">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/cl_container"
@@ -129,9 +130,9 @@
                     android:layout_marginTop="8dp"
                     android:background="@color/surface_1"
                     android:contentDescription="@string/add_gifticon_image_description"
+                    android:enabled="@{vm.isSelected}"
                     android:onClick="@{() -> vm.gotoCropGifticon()}"
                     android:scaleType="centerCrop"
-                    android:enabled="@{vm.isSelected}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/rv_gifticon"
@@ -156,6 +157,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
                     android:background="@color/gray"
+                    android:enabled="@{vm.isSelected}"
                     android:gravity="center"
                     android:onClick="@{() -> vm.showOriginGifticon()}"
                     android:padding="12dp"
@@ -163,7 +165,6 @@
                     android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
                     android:textColor="@color/white"
                     android:textStyle="bold"
-                    android:enabled="@{vm.isSelected}"
                     app:layout_constraintEnd_toEndOf="@id/guideline_end"
                     app:layout_constraintStart_toStartOf="@id/guideline_start"
                     app:layout_constraintTop_toBottomOf="@id/iv_gifticon_image" />
@@ -215,10 +216,10 @@
                     style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:enabled="@{vm.isSelected}"
                     app:boxBackgroundColor="@null"
                     app:endIconMode="clear_text"
                     app:hintEnabled="false"
-                    android:enabled="@{vm.isSelected}"
                     app:layout_constraintEnd_toEndOf="@id/guideline_end"
                     app:layout_constraintStart_toStartOf="@id/guideline_start"
                     app:layout_constraintTop_toBottomOf="@id/tv_name">
@@ -251,10 +252,10 @@
                     style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:enabled="@{vm.isSelected}"
                     app:boxBackgroundColor="@null"
                     app:endIconMode="clear_text"
                     app:hintEnabled="false"
-                    android:enabled="@{vm.isSelected}"
                     app:layout_constraintEnd_toEndOf="@id/guideline_end"
                     app:layout_constraintStart_toStartOf="@id/guideline_start"
                     app:layout_constraintTop_toBottomOf="@id/tv_brand">
@@ -287,10 +288,10 @@
                     style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:enabled="@{vm.isSelected}"
                     app:boxBackgroundColor="@null"
                     app:endIconMode="clear_text"
                     app:hintEnabled="false"
-                    android:enabled="@{vm.isSelected}"
                     app:layout_constraintEnd_toEndOf="@id/guideline_end"
                     app:layout_constraintStart_toStartOf="@id/guideline_start"
                     app:layout_constraintTop_toBottomOf="@id/tv_barcode">
@@ -303,47 +304,10 @@
                         android:imeOptions="actionNext"
                         android:inputType="number"
                         android:lines="1"
-                        android:maxLength="16"
-                        android:onTextChanged="@{(text, start, end, count) -> vm.changeBarcode(text)}"
+                        android:maxLength="19"
+                        android:onTextChanged="@{(text, start, end, count) -> vm.changeBarcode(text, start, end, count)}"
+                        android:selection="@{vm.barcodeSelection}"
                         android:text="@{vm.barcode}" />
-
-                </com.google.android.material.textfield.TextInputLayout>
-
-                <TextView
-                    android:id="@+id/tv_expire_date"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="12dp"
-                    android:text="@string/add_gifticon_expire_date_label"
-                    android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
-                    app:layout_constraintStart_toStartOf="@id/guideline_start"
-                    app:layout_constraintTop_toBottomOf="@id/til_barcode" />
-
-                <com.google.android.material.textfield.TextInputLayout
-                    android:id="@+id/til_expire_date"
-                    style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    app:boxBackgroundColor="@null"
-                    app:endIconDrawable="@drawable/ic_add_gifticon_calendar"
-                    app:endIconMode="custom"
-                    app:hintEnabled="false"
-                    android:enabled="@{vm.isSelected}"
-                    app:layout_constraintEnd_toEndOf="@id/guideline_end"
-                    app:layout_constraintStart_toStartOf="@id/guideline_start"
-                    app:layout_constraintTop_toBottomOf="@id/tv_expire_date">
-
-                    <com.google.android.material.textfield.TextInputEditText
-                        android:id="@+id/tiet_expire_date"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:focusable="false"
-                        android:cursorVisible="false"
-                        android:hint="@string/add_gifticon_expire_date_hint"
-                        android:inputType="none"
-                        android:lines="1"
-                        android:onClick="@{() -> vm.showExpiredAtDatePicker()}"
-                        app:setUIText="@{vm.expiredAt}"/>
 
                 </com.google.android.material.textfield.TextInputLayout>
 
@@ -361,17 +325,17 @@
                     android:text="@string/add_gifticon_balance_label"
                     android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
                     app:layout_constraintStart_toStartOf="@id/guideline_start"
-                    app:layout_constraintTop_toBottomOf="@id/til_expire_date" />
+                    app:layout_constraintTop_toBottomOf="@id/til_barcode" />
 
                 <com.google.android.material.textfield.TextInputLayout
                     android:id="@+id/til_balance"
                     style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:enabled="@{vm.isSelected}"
                     app:boxBackgroundColor="@null"
                     app:endIconMode="clear_text"
                     app:hintEnabled="false"
-                    android:enabled="@{vm.isSelected}"
                     app:layout_constraintEnd_toEndOf="@id/guideline_end"
                     app:layout_constraintStart_toStartOf="@id/guideline_start"
                     app:layout_constraintTop_toBottomOf="@id/tv_balance">
@@ -380,14 +344,52 @@
                         android:id="@+id/tiet_balance"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:hint="@string/add_gifticon_balance_hint"
-                        android:inputType="number"
-                        android:imeOptions="actionNext"
-                        android:lines="1"
                         android:filters="@{vm.balanceFilters}"
+                        android:hint="@string/add_gifticon_balance_hint"
+                        android:imeOptions="actionNext"
+                        android:inputType="number"
+                        android:lines="1"
                         android:onTextChanged="@{(text, start, end, count) -> vm.changeBalance(text, start, end, count)}"
-                        android:text="@{vm.balance}"
-                        android:selection="@{vm.balanceSelection}"/>
+                        android:selection="@{vm.balanceSelection}"
+                        android:text="@{vm.balance}" />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <TextView
+                    android:id="@+id/tv_expire_date"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:text="@string/add_gifticon_expire_date_label"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
+                    app:layout_constraintStart_toStartOf="@id/guideline_start"
+                    app:layout_constraintTop_toBottomOf="@id/tv_balance" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/til_expire_date"
+                    style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:enabled="@{vm.isSelected}"
+                    app:boxBackgroundColor="@null"
+                    app:endIconDrawable="@drawable/ic_add_gifticon_calendar"
+                    app:endIconMode="custom"
+                    app:hintEnabled="false"
+                    app:layout_constraintEnd_toEndOf="@id/guideline_end"
+                    app:layout_constraintStart_toStartOf="@id/guideline_start"
+                    app:layout_constraintTop_toBottomOf="@id/tv_expire_date">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/tiet_expire_date"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:cursorVisible="false"
+                        android:focusable="false"
+                        android:hint="@string/add_gifticon_expire_date_hint"
+                        android:inputType="none"
+                        android:lines="1"
+                        android:onClick="@{() -> vm.showExpiredAtDatePicker()}"
+                        app:setUIText="@{vm.expiredAt}" />
 
                 </com.google.android.material.textfield.TextInputLayout>
 
@@ -399,17 +401,17 @@
                     android:text="@string/add_gifticon_memo_label"
                     android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
                     app:layout_constraintStart_toStartOf="@id/guideline_start"
-                    app:layout_constraintTop_toBottomOf="@id/til_balance" />
+                    app:layout_constraintTop_toBottomOf="@id/til_expire_date" />
 
                 <com.google.android.material.textfield.TextInputLayout
                     android:id="@+id/til_memo"
                     style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:enabled="@{vm.isSelected}"
                     app:boxBackgroundColor="@null"
                     app:endIconMode="clear_text"
                     app:hintEnabled="false"
-                    android:enabled="@{vm.isSelected}"
                     app:layout_constraintEnd_toEndOf="@id/guideline_end"
                     app:layout_constraintStart_toStartOf="@id/guideline_start"
                     app:layout_constraintTop_toBottomOf="@id/tv_memo">

--- a/presentation/src/main/res/layout/activity_crop_gifticon.xml
+++ b/presentation/src/main/res/layout/activity_crop_gifticon.xml
@@ -14,43 +14,49 @@
         android:layout_height="match_parent"
         android:background="@color/black">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/cl_toolbar"
-            android:layout_width="0dp"
-            android:layout_height="?attr/actionBarSize"
-            android:background="?attr/colorPrimary"
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/app_bar_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fitsSystemWindows="true"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
-            <ImageView
-                android:id="@+id/iv_back"
-                android:layout_width="48dp"
-                android:layout_height="48dp"
-                android:layout_marginStart="4dp"
-                android:contentDescription="@string/add_gifticon_back_description"
-                android:onClick="@{() -> vm.cancelCropImage()}"
-                android:padding="12dp"
-                android:src="@drawable/ic_back"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:tint="?attr/colorOnPrimary" />
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/cl_toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize">
 
-            <TextView
-                android:id="@+id/tv_complete"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="16dp"
-                android:onClick="@{() -> vm.requestCropImage()}"
-                android:text="@string/crop_gifticon_complete"
-                android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
-                android:textColor="?attr/colorOnPrimary"
-                android:textStyle="bold"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                <ImageView
+                    android:id="@+id/iv_back"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:layout_marginStart="4dp"
+                    android:contentDescription="@string/add_gifticon_back_description"
+                    android:onClick="@{() -> vm.cancelCropImage()}"
+                    android:padding="12dp"
+                    android:src="@drawable/ic_back"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:tint="?attr/colorOnPrimarySurface" />
+
+                <TextView
+                    android:id="@+id/tv_complete"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="16dp"
+                    android:onClick="@{() -> vm.requestCropImage()}"
+                    android:text="@string/crop_gifticon_complete"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
+                    android:textColor="?attr/colorOnPrimary"
+                    android:textStyle="bold"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </com.google.android.material.appbar.AppBarLayout>
 
         <com.lighthouse.presentation.ui.cropgifticon.view.CropImageView
             android:id="@+id/crop_image_view"
@@ -60,7 +66,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/cl_toolbar"
+            app:layout_constraintTop_toBottomOf="@id/app_bar_layout"
             app:onCropImageListener="@{(bitmap, rect) -> vm.onCropImageListener(bitmap, rect)}" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/layout/activity_gallery.xml
+++ b/presentation/src/main/res/layout/activity_gallery.xml
@@ -45,7 +45,8 @@
                         android:src="@drawable/ic_back"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent" />
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:tint="?attr/colorOnSurface" />
 
                     <TextView
                         android:id="@+id/tv_title"

--- a/presentation/src/main/res/layout/fragment_cash_card_gifticon_info.xml
+++ b/presentation/src/main/res/layout/fragment_cash_card_gifticon_info.xml
@@ -219,7 +219,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:afterTextChanged="@{(text) -> vm.editMemo(text.toString())}"
-            android:background="@drawable/bg_gifticon_detail_memo"
+            android:background="@drawable/bg_gifticon_memo"
             android:enabled="@{vm.mode == mode.EDIT}"
             android:gravity="top"
             android:hint="@string/gifticon_detail_memo_description"

--- a/presentation/src/main/res/layout/fragment_standard_gifticon_info.xml
+++ b/presentation/src/main/res/layout/fragment_standard_gifticon_info.xml
@@ -173,7 +173,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:afterTextChanged="@{(text) -> vm.editMemo(text.toString())}"
-            android:background="@drawable/bg_gifticon_detail_memo"
+            android:background="@drawable/bg_gifticon_memo"
             android:enabled="@{vm.mode == mode.EDIT}"
             android:gravity="top"
             android:hint="@string/gifticon_detail_memo_description"

--- a/presentation/src/main/res/layout/item_add_goto_gallery.xml
+++ b/presentation/src/main/res/layout/item_add_goto_gallery.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <ImageView
         android:id="@+id/iv_goto_gallery"
         android:layout_width="48dp"
         android:layout_height="48dp"
-        android:background="@color/surface_1"
+        android:background="@color/on_surface_12"
+        app:tint="?attr/colorOnSurface"
         android:contentDescription="@string/add_gifticon_goto_gallery_description"
         android:padding="12dp"
         android:src="@drawable/ic_add_goto_gallery" />

--- a/presentation/src/main/res/values-night/themes.xml
+++ b/presentation/src/main/res/values-night/themes.xml
@@ -7,7 +7,7 @@
         <item name="colorOnPrimary">?attr/colorOnSurface</item>
         <item name="colorSecondary">@color/beep_pink_dark</item>
         <item name="colorOnSecondary">@color/white</item>
-        <item name="android:statusBarColor">?attr/colorSurface</item>
+        <item name="android:statusBarColor">@color/on_surface_9</item>
     </style>
 
     <style name="Theme.BEEP.EditText" parent="Widget.AppCompat.EditText">

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -44,7 +44,6 @@
     <string name="add_gifticon_cash_card">금액권</string>
     <string name="add_gifticon_delete_mode">삭제하기</string>
     <string name="add_gifticon_edit_mode">편집하기</string>
-    <string name="add_gifticon_brand_description">기프티콘 브랜드 이미지</string>
     <string name="add_gifticon_name_label">이름</string>
     <string name="add_gifticon_name_hint">쿠폰 이름을 입력하세요.</string>
     <string name="add_gifticon_brand_label">브랜드</string>


### PR DESCRIPTION
resolved: #82
resolved: #83

## 작업 내용

- 유효기간 EditText 에 표시
- 유효기간의 Text 입력를 막고 무조건 Picker로 설정하게 변경
- 잔액에 ',' 을 포함하여 표시
- 바코드에 ' '을 포함하여 표시
- 각각 기프티콘별 Valid 확인 기능 추가
- Snack가 등록하기를 가리지 않게 변경
- IME Next 작업 설정
- 금액권 설정에 따른 Focus 처리와 키보드 처리
- EditTextInfo 를 이용한 Text, Selection 처리
- BrandImage 관련 로직 제거
- Memo UI 제거
- 다크 모드 대응 
- 기프티콘 추가 클릭 시 바로 갤러리로 이동

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정

## 동작 화면

### 유효기간 EditText 에 표시
![유효기간을 텍스트로 표시](https://user-images.githubusercontent.com/9216335/204342610-74109fdb-9fe1-448a-8ac1-fc67cd7d7ca6.png)

### 유효기간 DatePicker
![유표기간 DatePicker](https://user-images.githubusercontent.com/9216335/204342658-9b082b4e-bce4-44ce-a462-e0449c74c931.png)

### 잔액과 바코드 Format 으로 표시
![바코드와 잔액 글자 포멧](https://user-images.githubusercontent.com/9216335/204343016-baccdae7-adb0-404c-b8c0-9ceb8bc20bc9.png)

### 잔액에 ',' 를 포함된 상태로 텍스트 수정 
![Format Balance](https://user-images.githubusercontent.com/9216335/204342754-e66477ae-fad2-43fc-afd9-b5c8292973c7.gif)

### 바코드에 ' '을 포함된 상태로 텍스트 수정
![Format Barcode](https://user-images.githubusercontent.com/9216335/204342854-2151d2da-d11c-41dc-8d37-bcf3273f4d5e.gif)

### IME Next 설정
![IME Next 처리](https://user-images.githubusercontent.com/9216335/204342907-e707d2c4-09ed-468f-89a1-618dd6205116.gif)

### SnackBar 가 레이아웃을 가리지 않게 설정
![Snackbar 가 등록하기를 가리지 않게 변경](https://user-images.githubusercontent.com/9216335/204343108-5e79cee5-45e1-4103-ba20-8fa5135b2090.gif)
