### PR TITLE
기프티콘 사용 로직 작성

### DIFF
--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/Event.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/Event.kt
@@ -10,5 +10,5 @@ sealed class Event {
     data class OnGifticonInfoChanged(val before: Gifticon, val after: Gifticon) : Event()
     object ExpireDateClicked : Event()
     object UseGifticonButtonClicked : Event()
-    object Complete : Event()
+    object UseGifticonComplete : Event()
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/Event.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/Event.kt
@@ -10,4 +10,5 @@ sealed class Event {
     data class OnGifticonInfoChanged(val before: Gifticon, val after: Gifticon) : Event()
     object ExpireDateClicked : Event()
     object UseGifticonButtonClicked : Event()
+    object Complete : Event()
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailActivity.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailActivity.kt
@@ -171,7 +171,7 @@ class GifticonDetailActivity : AppCompatActivity() {
             is Event.ShowAllUsedInfoButtonClicked -> {
                 showUsageHistoryDialog()
             }
-            is Event.Complete -> {
+            is Event.UseGifticonComplete -> {
                 if (::useGifticonDialog.isInitialized && useGifticonDialog.isAdded) {
                     useGifticonDialog.dismiss()
                 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailActivity.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailActivity.kt
@@ -104,6 +104,11 @@ class GifticonDetailActivity : AppCompatActivity(), AuthCallback {
             }
         }
         repeatOnStarted {
+            viewModel.tempGifticon.collect { gifticon ->
+                spinnerDatePicker.setDate(gifticon?.expireAt ?: return@collect)
+            }
+        }
+        repeatOnStarted {
             viewModel.mode.collect { mode ->
                 when (mode) {
                     GifticonDetailMode.UNUSED -> {
@@ -172,7 +177,7 @@ class GifticonDetailActivity : AppCompatActivity(), AuthCallback {
 
     private val spinnerDatePicker = SpinnerDatePicker().apply {
         setOnDatePickListener { year, month, dayOfMonth ->
-            Timber.tag("TEST").d("$year/$month/$dayOfMonth")
+            viewModel.editExpireDate(year, month, dayOfMonth)
         }
     }
 

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailActivity.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailActivity.kt
@@ -36,7 +36,7 @@ import timber.log.Timber
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class GifticonDetailActivity : AppCompatActivity(), AuthCallback {
+class GifticonDetailActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityGifticonDetailBinding
     private val viewModel: GifticonDetailViewModel by viewModels()
@@ -52,6 +52,7 @@ class GifticonDetailActivity : AppCompatActivity(), AuthCallback {
 
     private lateinit var checkEditDialog: AlertDialog
     private lateinit var usageHistoryDialog: AlertDialog
+    private lateinit var useGifticonDialog: UseGifticonDialog
     private lateinit var gifticonInfoChangedSnackbar: Snackbar
     private lateinit var gifticonInfoNotChangedToast: Toast
 
@@ -66,9 +67,25 @@ class GifticonDetailActivity : AppCompatActivity(), AuthCallback {
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             when (result.resultCode) {
                 Activity.RESULT_OK -> authenticate()
-                else -> onAuthError()
+                else -> authCallback.onAuthError()
             }
         }
+    private val authCallback = object : AuthCallback {
+        override fun onAuthSuccess() {
+            showUseGifticonDialog()
+        }
+
+        override fun onAuthCancel() {
+        }
+
+        override fun onAuthError(@StringRes stringId: Int?) {
+            if (stringId != null) {
+                Toast.makeText(this@GifticonDetailActivity, getString(stringId), Toast.LENGTH_SHORT).show()
+            } else {
+                authenticate()
+            }
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -154,6 +171,11 @@ class GifticonDetailActivity : AppCompatActivity(), AuthCallback {
             is Event.ShowAllUsedInfoButtonClicked -> {
                 showUsageHistoryDialog()
             }
+            is Event.Complete -> {
+                if (::useGifticonDialog.isInitialized && useGifticonDialog.isAdded) {
+                    useGifticonDialog.dismiss()
+                }
+            }
             else -> { // TODO(이벤트 처리)
             }
         }
@@ -186,7 +208,9 @@ class GifticonDetailActivity : AppCompatActivity(), AuthCallback {
     }
 
     private fun showUseGifticonDialog() {
-        UseGifticonDialog().show(supportFragmentManager, UseGifticonDialog.TAG)
+        useGifticonDialog = UseGifticonDialog().also { dialog ->
+            dialog.show(supportFragmentManager, UseGifticonDialog.TAG)
+        }
     }
 
     private fun showUsageHistoryDialog() {
@@ -231,22 +255,7 @@ class GifticonDetailActivity : AppCompatActivity(), AuthCallback {
     }
 
     private fun authenticate() {
-        authManager.auth(this, biometricLauncher, this)
-    }
-
-    override fun onAuthSuccess() {
-        Timber.tag("Auth").d("onAuthSuccess")
-        showUseGifticonDialog()
-    }
-
-    override fun onAuthCancel() {
-        Timber.tag("Auth").d("onAuthCancel")
-    }
-
-    override fun onAuthError(@StringRes stringId: Int?) {
-        Timber.tag("Auth").d("onAuthError")
-        // TODO: StringId가 null 이 아니라면 정의된 에러 메세지가 존재하는 경우입니다. null 체크하고 출력하면 어떨까요?
-        authenticate()
+        authManager.auth(this, biometricLauncher, authCallback)
     }
 
     private fun showGifticonInfoChangedSnackBar(before: Gifticon) {

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailViewModel.kt
@@ -124,19 +124,6 @@ class GifticonDetailViewModel @Inject constructor(
     }
 
     fun completeUseGifticonButtonClicked() {
-        if (gifticon.value?.isCashCard == true) {
-            viewModelScope.launch {
-                assert((gifticon.value?.balance ?: 0) >= amountToBeUsed.value)
-                useCashCardGifticonUseCase(gifticonId, amountToBeUsed.value)
-                amountToBeUsed.value = 0
-                event(Event.UseGifticonComplete)
-            }
-        } else {
-            viewModelScope.launch {
-                useGifticonUseCase(gifticonId)
-                event(Event.UseGifticonComplete)
-            }
-        }
         viewModelScope.launch {
             if (gifticon.value?.isCashCard == true) {
                 assert((gifticon.value?.balance ?: 0) >= amountToBeUsed.value)

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailViewModel.kt
@@ -129,12 +129,23 @@ class GifticonDetailViewModel @Inject constructor(
                 assert((gifticon.value?.balance ?: 0) >= amountToBeUsed.value)
                 useCashCardGifticonUseCase(gifticonId, amountToBeUsed.value)
                 amountToBeUsed.value = 0
-                event(Event.Complete)
+                event(Event.UseGifticonComplete)
             }
         } else {
             viewModelScope.launch {
                 useGifticonUseCase(gifticonId)
-                event(Event.Complete)
+                event(Event.UseGifticonComplete)
+            }
+        }
+        viewModelScope.launch {
+            if (gifticon.value?.isCashCard == true) {
+                assert((gifticon.value?.balance ?: 0) >= amountToBeUsed.value)
+                useCashCardGifticonUseCase(gifticonId, amountToBeUsed.value)
+                amountToBeUsed.value = 0
+                event(Event.UseGifticonComplete)
+            } else {
+                useGifticonUseCase(gifticonId)
+                event(Event.UseGifticonComplete)
             }
         }
     }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailViewModel.kt
@@ -109,14 +109,6 @@ class GifticonDetailViewModel @Inject constructor(
         when (mode.value) {
             GifticonDetailMode.UNUSED -> {
                 event(Event.UseGifticonButtonClicked)
-                viewModelScope.launch {
-                    if (gifticon.value?.isCashCard == true) {
-//                        useCashCardGifticonUseCase(gifticonId, amountToUse.value) // TODO 이걸로 사용해야 함
-                        useGifticonUseCase(gifticonId) // TODO 이건 제거
-                    } else {
-                        useGifticonUseCase(gifticonId)
-                    }
-                }
             }
             GifticonDetailMode.USED -> {
                 viewModelScope.launch {
@@ -127,6 +119,21 @@ class GifticonDetailViewModel @Inject constructor(
                 // TODO(수정사항 반영)
                 _mode.update { GifticonDetailMode.UNUSED }
                 endEdit()
+            }
+        }
+    }
+
+    fun completeUseGifticonButtonClicked() {
+        if (gifticon.value?.isCashCard == true) {
+            viewModelScope.launch {
+                assert((gifticon.value?.balance ?: 0) >= amountToBeUsed.value)
+                useCashCardGifticonUseCase(gifticonId, amountToBeUsed.value)
+                event(Event.Complete)
+            }
+        } else {
+            viewModelScope.launch {
+                useGifticonUseCase(gifticonId)
+                event(Event.Complete)
             }
         }
     }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailViewModel.kt
@@ -128,6 +128,7 @@ class GifticonDetailViewModel @Inject constructor(
             viewModelScope.launch {
                 assert((gifticon.value?.balance ?: 0) >= amountToBeUsed.value)
                 useCashCardGifticonUseCase(gifticonId, amountToBeUsed.value)
+                amountToBeUsed.value = 0
                 event(Event.Complete)
             }
         } else {

--- a/presentation/src/main/res/layout/dialog_use_gifticon.xml
+++ b/presentation/src/main/res/layout/dialog_use_gifticon.xml
@@ -164,6 +164,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="32dp"
+                android:onClick="@{() -> vm.completeUseGifticonButtonClicked()}"
                 android:text="@string/use_gifticon_dialog_complete_button_text"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="@id/guid_end"


### PR DESCRIPTION
resolved: #115

## 작업 내용

기프티콘 사용 로직을 작성했습니다

1. 보안 인증
2. 인증 성공 시 다이얼로그 띄우기
2.1. 인증 실패 시 다시 요구
2.2. 에러 메시지가 존재하는 경우 메시지를 띄우고 인증 종료
3. [사용 완료] 버튼 클릭 시 사용 완료 처리
3.1. [사용 완료] 안 누르면 사용 처리 안 함

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정

## 동작 화면

### 잔액 5,000원 -> 3천원 사용 (아직 사용할 수 있는 상태. 잔액이 2,000 원으로 바뀜)

<img src="https://user-images.githubusercontent.com/44221447/205985150-61427e31-6245-4c06-a5e8-99791ca8b03d.gif" width="33%" />

### 잔액 2,000원 -> 전액 사용 (사용 완료 처리 됨)

<img src="https://user-images.githubusercontent.com/44221447/205985134-5f840d74-0161-4f89-b560-17da4088c052.gif" width="33%" />

### 사용 기록 확인 (위치 정보는 아직 구현되지 않음)

<img src="https://user-images.githubusercontent.com/44221447/205985124-0fc64435-5cfd-4b82-9104-034802957ada.png" width="33%" />
