### PR TITLE
기프티콘 자동 파서 개선

### DIFF
--- a/data/src/main/java/com/lighthouse/database/dao/GifticonDao.kt
+++ b/data/src/main/java/com/lighthouse/database/dao/GifticonDao.kt
@@ -118,6 +118,9 @@ interface GifticonDao {
     @Query("SELECT EXISTS (SELECT * FROM $GIFTICON_TABLE WHERE expire_at >= :time AND is_used = 0 AND user_id = :userId)")
     fun hasUsableGifticon(userId: String, time: Date): Flow<Boolean>
 
+    @Query("SELECT EXISTS(SELECT 1 from $GIFTICON_TABLE WHERE LOWER(brand)=:brand LIMIT 1)")
+    suspend fun hasGifticonBrand(brand: String): Boolean
+
     @Query("UPDATE $GIFTICON_TABLE SET user_id = :newUserId WHERE user_id = :oldUserId")
     suspend fun moveUserIdGifticon(oldUserId: String, newUserId: String)
 }

--- a/data/src/main/java/com/lighthouse/datasource/gifticon/GifticonLocalDataSource.kt
+++ b/data/src/main/java/com/lighthouse/datasource/gifticon/GifticonLocalDataSource.kt
@@ -28,5 +28,6 @@ interface GifticonLocalDataSource {
     fun getGifticonByBrand(brand: String): Flow<List<GifticonEntity>>
     fun hasUsableGifticon(userId: String): Flow<Boolean>
     fun getUsableGifticons(userId: String): Flow<List<GifticonEntity>>
+    suspend fun hasGifticonBrand(brand: String): Boolean
     suspend fun moveUserIdGifticon(oldUserId: String, newUserId: String)
 }

--- a/data/src/main/java/com/lighthouse/datasource/gifticon/GifticonLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/lighthouse/datasource/gifticon/GifticonLocalDataSourceImpl.kt
@@ -106,6 +106,10 @@ class GifticonLocalDataSourceImpl @Inject constructor(
         return gifticonDao.getAllUsableGifticons(userId, today)
     }
 
+    override suspend fun hasGifticonBrand(brand: String): Boolean {
+        return gifticonDao.hasGifticonBrand(brand)
+    }
+
     override suspend fun moveUserIdGifticon(oldUserId: String, newUserId: String) {
         gifticonDao.moveUserIdGifticon(oldUserId, newUserId)
     }

--- a/data/src/main/java/com/lighthouse/repository/GifticonRepositoryImpl.kt
+++ b/data/src/main/java/com/lighthouse/repository/GifticonRepositoryImpl.kt
@@ -150,6 +150,8 @@ class GifticonRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun hasGifticonBrand(brand: String) = gifticonLocalDataSource.hasGifticonBrand(brand)
+
     override suspend fun moveUserIdGifticon(oldUserId: String, newUserId: String) {
         gifticonLocalDataSource.moveUserIdGifticon(oldUserId, newUserId)
     }

--- a/data/src/main/java/com/lighthouse/util/recognizer/processor/BaseProcessor.kt
+++ b/data/src/main/java/com/lighthouse/util/recognizer/processor/BaseProcessor.kt
@@ -39,9 +39,7 @@ abstract class BaseProcessor : ScaleProcessor() {
         bottomPercent: Float
     ): GifticonProcessText {
         val croppedImage = cropImage(bitmap, leftPercent, topPercent, rightPercent, bottomPercent)
-        val image = scaleProcess(croppedImage.bitmap)
-        croppedImage.bitmap.recycle()
-        return GifticonProcessText(tag, image)
+        return GifticonProcessText(tag, croppedImage.bitmap)
     }
 
     protected open fun preprocess(bitmap: Bitmap): Bitmap = bitmap

--- a/domain/src/main/java/com/lighthouse/domain/repository/GifticonRepository.kt
+++ b/domain/src/main/java/com/lighthouse/domain/repository/GifticonRepository.kt
@@ -30,6 +30,7 @@ interface GifticonRepository {
     fun getGifticonByBrand(brand: String): Flow<DbResult<List<Gifticon>>>
     fun hasUsableGifticon(userId: String): Flow<Boolean>
     fun getUsableGifticons(userId: String): Flow<DbResult<List<Gifticon>>>
+    suspend fun hasGifticonBrand(brand: String): Boolean
 
     fun getGifticonCrop(gifticonId: String): Flow<GifticonCrop>
     suspend fun updateGifticonCrop(gifticonCrop: GifticonCrop)

--- a/domain/src/main/java/com/lighthouse/domain/usecase/addgifticon/HasGifticonBrandUseCase.kt
+++ b/domain/src/main/java/com/lighthouse/domain/usecase/addgifticon/HasGifticonBrandUseCase.kt
@@ -1,0 +1,12 @@
+package com.lighthouse.domain.usecase.addgifticon
+
+import com.lighthouse.domain.repository.GifticonRepository
+import javax.inject.Inject
+
+class HasGifticonBrandUseCase @Inject constructor(
+    private val gifticonRepository: GifticonRepository
+) {
+    suspend operator fun invoke(brand: String): Boolean {
+        return gifticonRepository.hasGifticonBrand(brand)
+    }
+}

--- a/presentation/src/main/java/com/lighthouse/presentation/binding/EditText.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/binding/EditText.kt
@@ -1,12 +1,15 @@
 package com.lighthouse.presentation.binding
 
+import android.text.Selection
 import android.widget.EditText
 import androidx.databinding.BindingAdapter
 import com.lighthouse.presentation.model.EditTextInfo
+import java.lang.Integer.min
 
 @BindingAdapter("setEditTextInfo")
 fun setEditTextInfo(editText: EditText, info: EditTextInfo?) {
     info ?: return
     editText.setText(info.text)
-    editText.setSelection(info.selection)
+    val editable = editText.text
+    Selection.setSelection(editable, min(info.selection, editable.length))
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/extension/DialogFragment.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/extension/DialogFragment.kt
@@ -1,0 +1,8 @@
+package com.lighthouse.presentation.extension
+
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentManager
+
+fun DialogFragment.show(fragmentManager: FragmentManager) {
+    show(fragmentManager, javaClass.name)
+}

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonActivity.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonActivity.kt
@@ -143,6 +143,7 @@ class AddGifticonActivity : AppCompatActivity() {
                     is AddGifticonEvent.ShowExpiredAtDatePicker -> showExpiredAtDatePicker(events.date)
                     is AddGifticonEvent.RequestLoading -> requestLoading(events.loading)
                     is AddGifticonEvent.RequestFocus -> requestFocus(events.focus)
+                    is AddGifticonEvent.RequestScroll -> requestScroll(events.scroll)
                     is AddGifticonEvent.ShowSnackBar -> showSnackBar(events.uiText)
                     is AddGifticonEvent.RegistrationCompleted -> completeAddGifticon()
                 }
@@ -256,6 +257,14 @@ class AddGifticonActivity : AppCompatActivity() {
         } else {
             inputMethodService.hideSoftInputFromWindow(currentFocus?.windowToken, InputMethodManager.HIDE_NOT_ALWAYS)
         }
+    }
+
+    private fun requestScroll(scroll: AddGifticonScroll) {
+        val focusView = when (scroll) {
+            AddGifticonScroll.GIFTICON_NAME -> binding.tvName
+            AddGifticonScroll.BRAND_NAME -> binding.tvBrand
+        }
+        binding.nsv.smoothScrollTo(0, focusView.top)
     }
 
     private fun showSnackBar(uiText: UIText) {

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonActivity.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonActivity.kt
@@ -22,6 +22,7 @@ import com.lighthouse.presentation.extension.dp
 import com.lighthouse.presentation.extension.getParcelable
 import com.lighthouse.presentation.extension.getParcelableArrayList
 import com.lighthouse.presentation.extension.repeatOnStarted
+import com.lighthouse.presentation.extension.show
 import com.lighthouse.presentation.extra.Extras
 import com.lighthouse.presentation.model.CroppedImage
 import com.lighthouse.presentation.model.GalleryUIModel
@@ -29,6 +30,7 @@ import com.lighthouse.presentation.ui.addgifticon.adapter.AddGifticonAdapter
 import com.lighthouse.presentation.ui.addgifticon.adapter.AddGifticonItemUIModel
 import com.lighthouse.presentation.ui.addgifticon.dialog.OriginImageDialog
 import com.lighthouse.presentation.ui.common.dialog.ConfirmationDialog
+import com.lighthouse.presentation.ui.common.dialog.ProgressDialog
 import com.lighthouse.presentation.ui.common.dialog.datepicker.SpinnerDatePicker
 import com.lighthouse.presentation.ui.cropgifticon.CropGifticonActivity
 import com.lighthouse.presentation.ui.gallery.GalleryActivity
@@ -139,6 +141,7 @@ class AddGifticonActivity : AppCompatActivity() {
                     is AddGifticonEvent.NavigateToCropGifticon -> gotoCropGifticon(events.origin, events.croppedRect)
                     is AddGifticonEvent.ShowOriginGifticon -> showOriginGifticonDialog(events.origin)
                     is AddGifticonEvent.ShowExpiredAtDatePicker -> showExpiredAtDatePicker(events.date)
+                    is AddGifticonEvent.RequestLoading -> requestLoading(events.loading)
                     is AddGifticonEvent.RequestFocus -> requestFocus(events.focus)
                     is AddGifticonEvent.ShowSnackBar -> showSnackBar(events.uiText)
                     is AddGifticonEvent.RegistrationCompleted -> completeAddGifticon()
@@ -182,7 +185,7 @@ class AddGifticonActivity : AppCompatActivity() {
             arguments = Bundle().apply {
                 putParcelable(Extras.KEY_ORIGIN_IMAGE, uri)
             }
-        }.show(supportFragmentManager, OriginImageDialog::class.java.name)
+        }.show(supportFragmentManager)
     }
 
     private fun showExpiredAtDatePicker(date: Date) {
@@ -196,7 +199,7 @@ class AddGifticonActivity : AppCompatActivity() {
             }
         }.apply {
             setDate(date)
-        }.show(supportFragmentManager, SpinnerDatePicker::class.java.name)
+        }.show(supportFragmentManager)
     }
 
     private fun showConfirmationCancelDialog() {
@@ -220,6 +223,21 @@ class AddGifticonActivity : AppCompatActivity() {
                 viewModel.deleteGifticon(gifticon)
             }
         }.show(supportFragmentManager, CONFIRMATION_DELETE_DIALOG)
+    }
+
+    private var progressDialog: ProgressDialog? = null
+
+    private fun requestLoading(loading: Boolean) {
+        if (progressDialog?.isAdded == true) {
+            progressDialog?.dismiss()
+        }
+        progressDialog = if (loading) {
+            ProgressDialog().also {
+                it.show(supportFragmentManager)
+            }
+        } else {
+            null
+        }
     }
 
     private fun requestFocus(focus: AddGifticonFocus) {

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonEvent.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonEvent.kt
@@ -19,5 +19,6 @@ sealed class AddGifticonEvent {
     data class ShowExpiredAtDatePicker(val date: Date) : AddGifticonEvent()
     data class RequestLoading(val loading: Boolean) : AddGifticonEvent()
     data class RequestFocus(val focus: AddGifticonFocus) : AddGifticonEvent()
+    data class RequestScroll(val scroll: AddGifticonScroll) : AddGifticonEvent()
     data class ShowSnackBar(val uiText: UIText) : AddGifticonEvent()
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonEvent.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonEvent.kt
@@ -17,6 +17,7 @@ sealed class AddGifticonEvent {
     data class NavigateToCropGifticon(val origin: Uri, val croppedRect: RectF) : AddGifticonEvent()
     data class ShowOriginGifticon(val origin: Uri) : AddGifticonEvent()
     data class ShowExpiredAtDatePicker(val date: Date) : AddGifticonEvent()
+    data class RequestLoading(val loading: Boolean) : AddGifticonEvent()
     data class RequestFocus(val focus: AddGifticonFocus) : AddGifticonEvent()
     data class ShowSnackBar(val uiText: UIText) : AddGifticonEvent()
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonScroll.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonScroll.kt
@@ -1,0 +1,6 @@
+package com.lighthouse.presentation.ui.addgifticon
+
+enum class AddGifticonScroll {
+    GIFTICON_NAME,
+    BRAND_NAME
+}

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/addgifticon/AddGifticonViewModel.kt
@@ -25,6 +25,7 @@ import com.lighthouse.presentation.util.flow.MutableEventFlow
 import com.lighthouse.presentation.util.flow.asEventFlow
 import com.lighthouse.presentation.util.resource.UIText
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
@@ -93,9 +94,21 @@ class AddGifticonViewModel @Inject constructor(
         it?.name
     }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
+    fun onNameFocusChangeListener(hasFocus: Boolean) {
+        if (hasFocus) {
+            requestScroll(AddGifticonScroll.GIFTICON_NAME)
+        }
+    }
+
     val brand = selectedGifticon.map {
         it?.brandName
     }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    fun onBrandFocusChangeListener(hasFocus: Boolean) {
+        if (hasFocus) {
+            requestScroll(AddGifticonScroll.BRAND_NAME)
+        }
+    }
 
     private val displayBarcodeSelection = MutableStateFlow(0)
 
@@ -643,6 +656,13 @@ class AddGifticonViewModel @Inject constructor(
     private fun requestLoading(loading: Boolean) {
         viewModelScope.launch {
             _eventFlow.emit(AddGifticonEvent.RequestLoading(loading))
+        }
+    }
+
+    private fun requestScroll(scroll: AddGifticonScroll) {
+        viewModelScope.launch {
+            delay(400)
+            _eventFlow.emit(AddGifticonEvent.RequestScroll(scroll))
         }
     }
 

--- a/presentation/src/main/res/layout/activity_add_gifticon.xml
+++ b/presentation/src/main/res/layout/activity_add_gifticon.xml
@@ -15,56 +15,50 @@
         android:layout_height="match_parent">
 
         <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/abl"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:fitsSystemWindows="true"
             app:liftOnScroll="true">
 
-            <com.google.android.material.appbar.CollapsingToolbarLayout
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/cl_toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
-                app:layout_scrollFlags="scroll|exitUntilCollapsed"
-                app:toolbarId="@id/cl_toolbar">
+                android:minHeight="?attr/actionBarSize"
+                app:layout_collapseMode="pin">
 
-                <androidx.constraintlayout.widget.ConstraintLayout
-                    android:id="@+id/cl_toolbar"
-                    android:layout_width="match_parent"
-                    android:layout_height="?attr/actionBarSize"
-                    android:minHeight="?attr/actionBarSize"
-                    app:layout_collapseMode="pin">
+                <ImageView
+                    android:id="@+id/iv_back"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:layout_marginStart="4dp"
+                    android:contentDescription="@string/add_gifticon_back_description"
+                    android:onClick="@{() -> vm.requestPopBackstack()}"
+                    android:padding="12dp"
+                    android:src="@drawable/ic_back"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:tint="?attr/colorOnPrimary" />
 
-                    <ImageView
-                        android:id="@+id/iv_back"
-                        android:layout_width="48dp"
-                        android:layout_height="48dp"
-                        android:layout_marginStart="4dp"
-                        android:contentDescription="@string/add_gifticon_back_description"
-                        android:onClick="@{() -> vm.requestPopBackstack()}"
-                        android:padding="12dp"
-                        android:src="@drawable/ic_back"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent"
-                        app:tint="?attr/colorOnPrimary" />
+                <TextView
+                    android:id="@+id/tv_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:text="@string/add_gifticon_title"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Headline6"
+                    android:textColor="?attr/colorOnPrimary"
+                    app:layout_constraintBottom_toBottomOf="@id/iv_back"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/iv_back" />
 
-                    <TextView
-                        android:id="@+id/tv_title"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:gravity="center"
-                        android:text="@string/add_gifticon_title"
-                        android:textAppearance="@style/TextAppearance.MaterialComponents.Headline6"
-                        android:textColor="?attr/colorOnPrimary"
-                        app:layout_constraintBottom_toBottomOf="@id/iv_back"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="@id/iv_back" />
-
-                </androidx.constraintlayout.widget.ConstraintLayout>
-            </com.google.android.material.appbar.CollapsingToolbarLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
         </com.google.android.material.appbar.AppBarLayout>
 
         <androidx.core.widget.NestedScrollView
+            android:id="@+id/nsv"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             app:layout_behavior="@string/appbar_scrolling_view_behavior"
@@ -227,6 +221,7 @@
                         android:inputType="textNoSuggestions"
                         android:lines="1"
                         android:onTextChanged="@{(text, start, end, count) -> vm.changeGifticonName(text)}"
+                        app:onFocusChangeListener="@{(v, hasFocus) -> vm.onNameFocusChangeListener(hasFocus)}"
                         android:text="@{vm.name}"
                         app:onEditorActionListener="@{(view, actionId, event) -> vm.onActionNextListener(actionId)}" />
 
@@ -264,6 +259,7 @@
                         android:inputType="textNoSuggestions"
                         android:lines="1"
                         android:onTextChanged="@{(text, start, end, count) -> vm.changeBrandName(text)}"
+                        app:onFocusChangeListener="@{(v, hasFocus) -> vm.onBrandFocusChangeListener(hasFocus)}"
                         android:text="@{vm.brand}"
                         app:onEditorActionListener="@{(view, actionId, event) -> vm.onActionNextListener(actionId)}" />
 


### PR DESCRIPTION
resolved: #162

- 기프티콘 자동파서 성능 개선
- 기프티콘 자동파서 버그 수정
- 브랜드 존재 여부에 따른 쿼리 추가
- 텍스트 인식에 Progress 추가
- 포커스에 따른 스크롤 적용

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정

## 동작 화면

### 다중 기프티콘 파싱 로딩

![2 다중 기프티콘 파싱 로딩 추가](https://user-images.githubusercontent.com/9216335/206508277-60d0d9e8-9594-437e-b1ec-75bdf235f162.gif)

### 포커스에 따른 스크롤

![3 각각 포커스에 따른 스크롤](https://user-images.githubusercontent.com/9216335/206508263-88acdbbf-2861-4f53-adf0-5a80e39bcbfe.gif)
