### PR TITLE
location manager 생명주기 변경

### DIFF
--- a/app/src/main/java/com/lighthouse/di/ProviderModule.kt
+++ b/app/src/main/java/com/lighthouse/di/ProviderModule.kt
@@ -6,7 +6,9 @@ import com.lighthouse.presentation.background.NotificationHelper
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityRetainedComponent
 import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.android.scopes.ActivityRetainedScoped
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
@@ -16,13 +18,18 @@ object ProviderModule {
 
     @Provides
     @Singleton
-    fun provideSharedLocationManager(
-        @ApplicationContext context: Context
-    ): SharedLocationManager = SharedLocationManager(context)
-
-    @Provides
-    @Singleton
     fun provideNotificationHelper(
         @ApplicationContext context: Context
     ): NotificationHelper = NotificationHelper(context)
+}
+
+@Module
+@InstallIn(ActivityRetainedComponent::class)
+object ActivityRetainedProviderModule {
+
+    @Provides
+    @ActivityRetainedScoped
+    fun provideSharedLocationManager(
+        context: Context
+    ): SharedLocationManager = SharedLocationManager(context)
 }

--- a/data/src/main/java/com/lighthouse/datasource/location/SharedLocationManager.kt
+++ b/data/src/main/java/com/lighthouse/datasource/location/SharedLocationManager.kt
@@ -13,6 +13,7 @@ import com.google.android.gms.location.LocationResult
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
 import com.lighthouse.domain.VertexLocation
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
@@ -20,10 +21,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.shareIn
+import javax.inject.Inject
 
 @SuppressLint("MissingPermission")
-class SharedLocationManager constructor(
-    private val context: Context
+class SharedLocationManager @Inject constructor(
+    @ApplicationContext private val context: Context
 ) {
     var receivingLocationUpdates = MutableStateFlow(hasLocationPermission())
         private set


### PR DESCRIPTION
resolved: #183

## 작업 내용

- locationManager 각 생명주기 공유하지 않게 변경
- 지도에서 홈으로 갈때 로케이션 콜백이 너무 느려서 변경
  - 지도에서 위치를 받고 30초대기를 해야 다음 위치 콜백이 나오는데 홈으로 바로 버리면 약 20초 넘게 대기해야함

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정