### PR TITLE
노티에서 상세화면 진입 시 백스택 추가

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -35,7 +35,9 @@
             android:screenOrientation="portrait" />
         <activity
             android:name=".ui.detailgifticon.GifticonDetailActivity"
-            android:screenOrientation="portrait" />
+            android:parentActivityName=".ui.main.MainActivity"
+            android:screenOrientation="portrait">
+        </activity>
         <activity
             android:name=".ui.map.MapActivity"
             android:screenOrientation="portrait" />

--- a/presentation/src/main/java/com/lighthouse/presentation/background/NotificationHelper.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/background/NotificationHelper.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.TaskStackBuilder
 import com.lighthouse.domain.model.Gifticon
 import com.lighthouse.presentation.R
 import com.lighthouse.presentation.extra.Extras
@@ -47,25 +48,28 @@ class NotificationHelper @Inject constructor(
 
     fun applyNotification(gifticon: Gifticon, remainDays: Int) {
         val intent = Intent(context, GifticonDetailActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
             putExtra(Extras.KEY_GIFTICON_ID, gifticon.id)
         }
 
         val code = gifticon.barcode.hashCode()
 
-        val pendingIntent = PendingIntent.getActivity(
-            context,
-            code,
-            intent,
-            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-        )
+        val gifticonDetailPendingIntent = TaskStackBuilder.create(context).run {
+            addNextIntentWithParentStack(intent)
+            getPendingIntent(code, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
+        }
 
         val builder = NotificationCompat.Builder(context, Extras.NOTIFICATION_CHANNEL)
             .setSmallIcon(R.drawable.ic_splash_beep)
             .setContentTitle(context.getString(R.string.notification_title))
-            .setContentText(String.format(context.getString(R.string.notification_description), gifticon.name, remainDays))
+            .setContentText(
+                String.format(
+                    context.getString(R.string.notification_description),
+                    gifticon.name,
+                    remainDays
+                )
+            )
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-            .setContentIntent(pendingIntent)
+            .setContentIntent(gifticonDetailPendingIntent)
             .setGroup(channelGroup)
 
         val notification = builder.build().apply {

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonListToolBar.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonListToolBar.kt
@@ -59,7 +59,7 @@ fun GifticonAppBar(
                     Text(
                         text = stringResource(id = sortBy.stringRes),
                         color = Color.White,
-                        style = MaterialTheme.typography.h5
+                        style = MaterialTheme.typography.h6
                     )
                     Icon(
                         modifier = Modifier.align(Alignment.CenterVertically),

--- a/presentation/src/main/res/layout/activity_gifticon_detail.xml
+++ b/presentation/src/main/res/layout/activity_gifticon_detail.xml
@@ -29,6 +29,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
                 app:layout_scrollFlags="scroll|enterAlwaysCollapsed"
+                app:navigationIcon="@drawable/ic_back"
+                app:navigationIconTint="?attr/colorOnPrimary"
                 app:title="@string/gifticon_detail_gifticon_detail_title"
                 app:titleCentered="true" />
         </com.google.android.material.appbar.AppBarLayout>


### PR DESCRIPTION
resolved: #208

## 작업 내용

- 노티에서 클릭해서 상세화면으로 진입하는 경우 홈화면을 백스택에 추가하여 뒤로가기 눌러도 바로 앱이 꺼지지 않도록 처리
- 상세 화면 앱바에 뒤로 가기 버튼 추가
- 목록 화면 앱바 타이틀 크기 줄임

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정

## 동작 화면

<img src="https://user-images.githubusercontent.com/44221447/206890771-faf2e5ba-8da5-4764-9128-affa349ee118.gif" width="33%" />

<img src="https://user-images.githubusercontent.com/44221447/206890726-a0bba880-7745-4b1f-8e34-3d293a679806.png" width="33%" />
