### PR TITLE
사용완료 기프티콘 탭 개선

### DIFF
--- a/presentation/src/main/java/com/lighthouse/presentation/extra/Extras.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/extra/Extras.kt
@@ -29,4 +29,6 @@ object Extras {
     const val KEY_WIDGET_BRAND = "Extra.Widget.Item.id"
     const val KEY_WIDGET_EVENT = "Extra.Widget.Event"
     const val WIDGET_EVENT_MAP = "gotoMap"
+
+    const val TAG_DETAIL_SETTING = "Extra.Detail.Setting"
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/main/MainActivity.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/main/MainActivity.kt
@@ -26,7 +26,6 @@ import com.lighthouse.presentation.ui.home.HomeFragmentContainer
 import com.lighthouse.presentation.ui.map.MapActivity
 import com.lighthouse.presentation.ui.security.SecurityActivity
 import com.lighthouse.presentation.ui.setting.SettingFragment
-import com.lighthouse.presentation.ui.setting.SettingSecurityFragment
 import com.lighthouse.presentation.util.resource.UIText
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.first
@@ -38,9 +37,14 @@ class MainActivity : AppCompatActivity() {
     private val viewModel: MainViewModel by viewModels()
     private val callback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
-            when (supportFragmentManager.fragments.first { it.isVisible }) {
+            when (val currentFragment = supportFragmentManager.fragments.first { it.isVisible }) {
                 is HomeFragmentContainer -> finish()
-                is SettingSecurityFragment -> {} // SettingSecurityFragment 에서 관리하는 부분을 옮기려고 했는데 안 되네요...
+                is SettingFragment -> {
+                    if (currentFragment.isSettingMainFragment()) {
+                        binding.bnv.selectedItemId = R.id.menu_home
+                        viewModel.gotoHome()
+                    }
+                }
                 else -> {
                     binding.bnv.selectedItemId = R.id.menu_home
                     viewModel.gotoHome()

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/setting/SettingFragment.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/setting/SettingFragment.kt
@@ -7,7 +7,9 @@ import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.commit
 import com.lighthouse.presentation.R
 import com.lighthouse.presentation.databinding.FragmentSettingBinding
+import com.lighthouse.presentation.extra.Extras
 import com.lighthouse.presentation.ui.common.viewBindings
+import com.lighthouse.presentation.ui.main.MainViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -15,6 +17,7 @@ class SettingFragment : Fragment(R.layout.fragment_setting) {
 
     private val binding: FragmentSettingBinding by viewBindings()
     private val viewModel: SettingViewModel by activityViewModels()
+    private val activityViewModel: MainViewModel by activityViewModels()
 
     private val settingMainFragment = SettingMainFragment()
 
@@ -26,5 +29,20 @@ class SettingFragment : Fragment(R.layout.fragment_setting) {
         }
         binding.vm = viewModel
         binding.lifecycleOwner = viewLifecycleOwner
+    }
+
+    fun isSettingMainFragment(): Boolean {
+        return if (childFragmentManager.fragments.size == 1) {
+            true
+        } else {
+            val detail = childFragmentManager.findFragmentByTag(Extras.TAG_DETAIL_SETTING)
+            if (detail != null) {
+                childFragmentManager.commit {
+                    remove(detail)
+                }
+                activityViewModel.gotoMenuItem(R.id.menu_setting)
+            }
+            false
+        }
     }
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/setting/SettingMainFragment.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/setting/SettingMainFragment.kt
@@ -28,6 +28,7 @@ import com.google.firebase.ktx.Firebase
 import com.lighthouse.presentation.R
 import com.lighthouse.presentation.background.BeepWorkManager
 import com.lighthouse.presentation.databinding.FragmentSettingMainBinding
+import com.lighthouse.presentation.extra.Extras
 import com.lighthouse.presentation.ui.common.dialog.ProgressDialog
 import com.lighthouse.presentation.ui.common.viewBindings
 import com.lighthouse.presentation.ui.main.MainViewModel
@@ -111,7 +112,7 @@ class SettingMainFragment : Fragment(R.layout.fragment_setting_main), AuthCallba
         activityViewModel.gotoMenuItem(-1)
         parentFragmentManager.commit {
             setCustomAnimations(R.anim.anim_slide_in_bottom, R.anim.anim_slide_out_top)
-            add(R.id.fcv_setting, settingSecurityFragment)
+            add(R.id.fcv_setting, settingSecurityFragment, Extras.TAG_DETAIL_SETTING)
         }
     }
 
@@ -119,7 +120,7 @@ class SettingMainFragment : Fragment(R.layout.fragment_setting_main), AuthCallba
         activityViewModel.gotoMenuItem(-1)
         parentFragmentManager.commit {
             setCustomAnimations(R.anim.anim_slide_in_bottom, R.anim.anim_slide_out_top)
-            add(R.id.fcv_setting, UsedGifticonFragment())
+            add(R.id.fcv_setting, UsedGifticonFragment(), Extras.TAG_DETAIL_SETTING)
         }
     }
 
@@ -163,7 +164,8 @@ class SettingMainFragment : Fragment(R.layout.fragment_setting_main), AuthCallba
                     val credential = GoogleAuthProvider.getCredential(account.idToken, null)
                     auth.signInWithCredential(credential).addOnCompleteListener { signInTask ->
                         if (signInTask.isSuccessful) {
-                            Snackbar.make(requireView(), getString(R.string.signin_success), Snackbar.LENGTH_SHORT).show()
+                            Snackbar.make(requireView(), getString(R.string.signin_success), Snackbar.LENGTH_SHORT)
+                                .show()
                             auth.uid?.let { viewModel.moveGuestData(it) }
                         } else {
                             Snackbar.make(requireView(), getString(R.string.signin_fail), Snackbar.LENGTH_SHORT).show()

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/setting/SettingMainFragment.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/setting/SettingMainFragment.kt
@@ -118,6 +118,7 @@ class SettingMainFragment : Fragment(R.layout.fragment_setting_main), AuthCallba
     private fun gotoUsedGifticon() {
         activityViewModel.gotoMenuItem(-1)
         parentFragmentManager.commit {
+            setCustomAnimations(R.anim.anim_slide_in_bottom, R.anim.anim_slide_out_top)
             add(R.id.fcv_setting, UsedGifticonFragment())
         }
     }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/setting/UsedGifticonFragment.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/setting/UsedGifticonFragment.kt
@@ -18,7 +18,7 @@ import com.lighthouse.presentation.ui.common.viewBindings
 import com.lighthouse.presentation.ui.detailgifticon.GifticonDetailActivity
 import com.lighthouse.presentation.ui.main.MainViewModel
 import com.lighthouse.presentation.ui.map.adapter.GifticonAdapter
-import com.lighthouse.presentation.util.recycler.ListSpaceItemDecoration
+import com.lighthouse.presentation.util.recycler.GridSpaceItemDecoration
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -28,12 +28,9 @@ class UsedGifticonFragment : Fragment(R.layout.fragment_used_gifticon) {
     private val viewModel: UsedGifticonViewModel by viewModels()
     private val activityViewModel: MainViewModel by activityViewModels()
 
-    private val itemDecoration = ListSpaceItemDecoration(
-        space = 4.dp,
-        start = 2.dp,
-        top = 4.dp,
-        end = 2.dp,
-        bottom = 4.dp
+    private val itemDecoration = GridSpaceItemDecoration(
+        4.dp,
+        4.dp
     )
 
     private lateinit var callback: OnBackPressedCallback

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/setting/UsedGifticonFragment.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/setting/UsedGifticonFragment.kt
@@ -28,10 +28,7 @@ class UsedGifticonFragment : Fragment(R.layout.fragment_used_gifticon) {
     private val viewModel: UsedGifticonViewModel by viewModels()
     private val activityViewModel: MainViewModel by activityViewModels()
 
-    private val itemDecoration = GridSpaceItemDecoration(
-        4.dp,
-        4.dp
-    )
+    private val itemDecoration = GridSpaceItemDecoration(8.dp, 8.dp)
 
     private lateinit var callback: OnBackPressedCallback
 
@@ -57,8 +54,8 @@ class UsedGifticonFragment : Fragment(R.layout.fragment_used_gifticon) {
         with(binding.rvUsedGifticon) {
             adapter = GifticonAdapter(GifticonViewHolderType.VERTICAL) { gifticon ->
                 gotoGifticonDetail(gifticon.id)
-                addItemDecoration(itemDecoration)
             }
+            addItemDecoration(itemDecoration)
         }
     }
 

--- a/presentation/src/main/res/layout/fragment_used_gifticon.xml
+++ b/presentation/src/main/res/layout/fragment_used_gifticon.xml
@@ -15,7 +15,8 @@
         android:layout_height="match_parent"
         android:background="?attr/colorSurface"
         android:onClick="@{null}"
-        tools:context=".ui.setting.UsedGifticonFragment">
+        tools:context=".ui.setting.UsedGifticonFragment"
+        >
 
         <TextView
             android:id="@+id/tv_used_title"
@@ -23,6 +24,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/setting_used_gifticon"
+            android:padding="16dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
@@ -30,7 +32,8 @@
             android:id="@+id/rv_used_gifticon"
             android:layout_width="wrap_content"
             android:layout_height="0dp"
-            android:layout_marginTop="8dp"
+            android:layout_marginHorizontal="8dp"
+            android:orientation="vertical"
             app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/presentation/src/main/res/layout/fragment_used_gifticon.xml
+++ b/presentation/src/main/res/layout/fragment_used_gifticon.xml
@@ -15,16 +15,17 @@
         android:layout_height="match_parent"
         android:background="?attr/colorSurface"
         android:onClick="@{null}"
-        tools:context=".ui.setting.UsedGifticonFragment"
-        >
+        tools:context=".ui.setting.UsedGifticonFragment">
 
         <TextView
             android:id="@+id/tv_used_title"
             style="@style/BEEP.TextStyle.H6"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginVertical="8dp"
+            android:layout_marginStart="36dp"
             android:text="@string/setting_used_gifticon"
-            android:padding="16dp"
+            app:layout_constraintBottom_toTopOf="@+id/rv_used_gifticon"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 

--- a/presentation/src/main/res/layout/item_gifticon_vertical.xml
+++ b/presentation/src/main/res/layout/item_gifticon_vertical.xml
@@ -27,35 +27,37 @@
                 app:filterToGray="@{gifticon.isUsed}"
                 app:layout_constraintDimensionRatio="1:1"
                 app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <ImageView
                 android:layout_width="0dp"
                 android:layout_height="0dp"
+                android:contentDescription="@string/gifticon_detail_used_image_label_not_date"
                 android:src="@drawable/img_stamp"
                 app:isVisible="@{gifticon.isUsed}"
                 app:layout_constraintBottom_toBottomOf="@id/iv_product"
                 app:layout_constraintEnd_toEndOf="@id/iv_product"
                 app:layout_constraintStart_toStartOf="@id/iv_product"
-                app:layout_constraintTop_toTopOf="@id/iv_product"
-                android:contentDescription="@string/gifticon_detail_used_image_label_not_date" />
+                app:layout_constraintTop_toTopOf="@id/iv_product" />
 
             <TextView
                 style="@style/BEEP.TextStyle.H5"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
-                android:text="@string/gifticon_detail_used_image_label_not_date"
                 android:gravity="center"
                 android:rotation="-20"
+                android:text="@string/gifticon_detail_used_image_label_not_date"
                 android:textColor="@color/white"
                 android:textStyle="bold"
                 app:isVisible="@{gifticon.isUsed}"
                 app:layout_constraintBottom_toBottomOf="@id/iv_product"
                 app:layout_constraintEnd_toEndOf="@id/iv_product"
+                app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="@id/iv_product"
                 app:layout_constraintTop_toTopOf="@id/iv_product"
-                 />
+                app:layout_constraintVertical_bias="0.0" />
 
             <TextView
                 android:id="@+id/tv_expire_at_label"
@@ -64,6 +66,7 @@
                 android:background="@drawable/bg_primary_corner_4"
                 android:gravity="center"
                 android:textAppearance="@style/BEEP.TextStyle.Caption.White"
+                app:isVisible="@{!gifticon.isUsed}"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 app:setDday="@{gifticon.expireAt}"
@@ -105,9 +108,9 @@
                 android:layout_marginVertical="8dp"
                 android:layout_marginEnd="4dp"
                 android:textAppearance="@style/BEEP.TextStyle.Caption.Gray"
+                app:dateFormat="@{gifticon.expireAt}"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:dateFormat="@{gifticon.expireAt}"
                 tools:text="~ 2022-11-08" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/item_gifticon_vertical.xml
+++ b/presentation/src/main/res/layout/item_gifticon_vertical.xml
@@ -24,10 +24,38 @@
                 android:layout_height="0dp"
                 android:adjustViewBounds="true"
                 android:scaleType="centerCrop"
+                app:filterToGray="@{gifticon.isUsed}"
                 app:layout_constraintDimensionRatio="1:1"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageView
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:src="@drawable/img_stamp"
+                app:isVisible="@{gifticon.isUsed}"
+                app:layout_constraintBottom_toBottomOf="@id/iv_product"
+                app:layout_constraintEnd_toEndOf="@id/iv_product"
+                app:layout_constraintStart_toStartOf="@id/iv_product"
+                app:layout_constraintTop_toTopOf="@id/iv_product"
+                android:contentDescription="@string/gifticon_detail_used_image_label_not_date" />
+
+            <TextView
+                style="@style/BEEP.TextStyle.H5"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:text="@string/gifticon_detail_used_image_label_not_date"
+                android:gravity="center"
+                android:rotation="-20"
+                android:textColor="@color/white"
+                android:textStyle="bold"
+                app:isVisible="@{gifticon.isUsed}"
+                app:layout_constraintBottom_toBottomOf="@id/iv_product"
+                app:layout_constraintEnd_toEndOf="@id/iv_product"
+                app:layout_constraintStart_toStartOf="@id/iv_product"
+                app:layout_constraintTop_toTopOf="@id/iv_product"
+                 />
 
             <TextView
                 android:id="@+id/tv_expire_at_label"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -156,6 +156,7 @@
     <string name="gifticon_detail_unused_mode_button_text">기프티콘 사용</string>
     <string name="gifticon_detail_used_mode_button_text">사용 취소</string>
     <string name="gifticon_detail_used_image_label">사용완료\n%4d.%02d.%02d</string>
+    <string name="gifticon_detail_used_image_label_not_date">사용완료\n%4d.%02d.%02d</string>
     <string name="gifticon_detail_check_edit_dialog_title">기프티콘 정보를 수정 하시겠습니까?</string>
     <string name="gifticon_detail_check_edit_dialog_positive_button">수정</string>
     <string name="gifticon_detail_check_edit_dialog_negative_button">취소</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -156,7 +156,7 @@
     <string name="gifticon_detail_unused_mode_button_text">기프티콘 사용</string>
     <string name="gifticon_detail_used_mode_button_text">사용 취소</string>
     <string name="gifticon_detail_used_image_label">사용완료\n%4d.%02d.%02d</string>
-    <string name="gifticon_detail_used_image_label_not_date">사용완료\n%4d.%02d.%02d</string>
+    <string name="gifticon_detail_used_image_label_not_date">사용완료</string>
     <string name="gifticon_detail_check_edit_dialog_title">기프티콘 정보를 수정 하시겠습니까?</string>
     <string name="gifticon_detail_check_edit_dialog_positive_button">수정</string>
     <string name="gifticon_detail_check_edit_dialog_negative_button">취소</string>


### PR DESCRIPTION
resolved: #217 

## 작업 내용

- 이미지에 사용 완료 표시
- 진입시 애니메이션 적용
- 백키 눌렀을 시 설정으로 나가기
    - 사용한 기프티콘 목록만 보고 설정으로 나가면 정상작동 했음.
    - 사용한 기프티콘 목록에서 기프티콘 상세 페이지를 보고 다시 백키를 눌렀을 때 childFragment(설정 Fragment 속 Fragment)에서는 인식이 안됨. 설정창이 나와야 하는데 사용한 기프티콘 목록이 사라지지 않았음.
    -> 일단 임시로 거추장스럽게 고쳤는데 추후 설정 프래그먼트를 한곳에서 관리하도록 리팩토링 할 때... 다시 고쳐보겠음...

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정

## 동작 화면


https://user-images.githubusercontent.com/69582122/206896973-e08c282c-8ce2-47ae-88f0-43021e3fe2b6.mp4



## 버그

- GridItemDecorater가 안 먹어요.. 먼가 잘못 적용하고 있는걸까요?