### PR TITLE
기프티콘 목록 스와이프로 사용처리/삭제

### DIFF
--- a/data/src/main/java/com/lighthouse/database/dao/GifticonDao.kt
+++ b/data/src/main/java/com/lighthouse/database/dao/GifticonDao.kt
@@ -69,6 +69,12 @@ interface GifticonDao {
     fun useCashCardGifticon(gifticonId: String, balance: Int)
 
     /**
+     * 기프티콘을 삭제한다
+     */
+    @Query("DELETE FROM $GIFTICON_TABLE WHERE id = :gifticonId")
+    suspend fun removeGifticon(gifticonId: String)
+
+    /**
      * 기프티콘의 사용 기록을 조회한다
      * */
     @Query("SELECT * FROM $USAGE_HISTORY_TABLE WHERE gifticon_id = :gifticonId")

--- a/data/src/main/java/com/lighthouse/database/entity/UsageHistoryEntity.kt
+++ b/data/src/main/java/com/lighthouse/database/entity/UsageHistoryEntity.kt
@@ -2,10 +2,22 @@ package com.lighthouse.database.entity
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.ForeignKey
 import com.lighthouse.database.entity.UsageHistoryEntity.Companion.USAGE_HISTORY_TABLE
 import java.util.Date
 
-@Entity(tableName = USAGE_HISTORY_TABLE, primaryKeys = ["gifticon_id", "date"])
+@Entity(
+    tableName = USAGE_HISTORY_TABLE,
+    primaryKeys = ["gifticon_id", "date"],
+    foreignKeys = [
+        ForeignKey(
+            entity = GifticonEntity::class,
+            parentColumns = arrayOf("id"),
+            childColumns = arrayOf("gifticon_id"),
+            onDelete = ForeignKey.CASCADE
+        )
+    ]
+)
 data class UsageHistoryEntity(
     @ColumnInfo(name = "gifticon_id") val gifticonId: String,
     @ColumnInfo(name = "date") val date: Date,

--- a/data/src/main/java/com/lighthouse/datasource/gifticon/GifticonLocalDataSource.kt
+++ b/data/src/main/java/com/lighthouse/datasource/gifticon/GifticonLocalDataSource.kt
@@ -24,6 +24,7 @@ interface GifticonLocalDataSource {
     suspend fun useGifticon(gifticonId: String, usageHistory: UsageHistory)
     suspend fun useCashCardGifticon(gifticonId: String, amount: Int, usageHistory: UsageHistory)
     suspend fun unUseGifticon(gifticonId: String)
+    suspend fun removeGifticon(gifticonId: String)
     fun getUsageHistory(gifticonId: String): Flow<List<UsageHistory>>
     suspend fun insertUsageHistory(gifticonId: String, usageHistory: UsageHistory)
     fun getGifticonByBrand(brand: String): Flow<List<GifticonEntity>>

--- a/data/src/main/java/com/lighthouse/datasource/gifticon/GifticonLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/lighthouse/datasource/gifticon/GifticonLocalDataSourceImpl.kt
@@ -89,6 +89,10 @@ class GifticonLocalDataSourceImpl @Inject constructor(
         gifticonDao.unUseGifticon(gifticonId)
     }
 
+    override suspend fun removeGifticon(gifticonId: String) {
+        gifticonDao.removeGifticon(gifticonId)
+    }
+
     override fun getUsageHistory(gifticonId: String): Flow<List<UsageHistory>> {
         return gifticonDao.getUsageHistory(gifticonId).map { list ->
             list.map { entity ->

--- a/data/src/main/java/com/lighthouse/repository/GifticonRepositoryImpl.kt
+++ b/data/src/main/java/com/lighthouse/repository/GifticonRepositoryImpl.kt
@@ -126,6 +126,10 @@ class GifticonRepositoryImpl @Inject constructor(
         gifticonLocalDataSource.unUseGifticon(gifticonId)
     }
 
+    override suspend fun removeGifticon(gifticonId: String) {
+        gifticonLocalDataSource.removeGifticon(gifticonId)
+    }
+
     override fun getGifticonByBrand(brand: String) = flow {
         emit(DbResult.Loading)
         gifticonLocalDataSource.getGifticonByBrand(brand).collect { gifticons ->

--- a/domain/src/main/java/com/lighthouse/domain/repository/GifticonRepository.kt
+++ b/domain/src/main/java/com/lighthouse/domain/repository/GifticonRepository.kt
@@ -29,6 +29,7 @@ interface GifticonRepository {
     suspend fun useGifticon(gifticonId: String, usageHistory: UsageHistory)
     suspend fun useCashCardGifticon(gifticonId: String, amount: Int, usageHistory: UsageHistory)
     suspend fun unUseGifticon(gifticonId: String)
+    suspend fun removeGifticon(gifticonId: String)
     fun getGifticonByBrand(brand: String): Flow<DbResult<List<Gifticon>>>
     fun hasUsableGifticon(userId: String): Flow<Boolean>
     fun getUsableGifticons(userId: String): Flow<DbResult<List<Gifticon>>>

--- a/domain/src/main/java/com/lighthouse/domain/usecase/RemoveGifticonUseCase.kt
+++ b/domain/src/main/java/com/lighthouse/domain/usecase/RemoveGifticonUseCase.kt
@@ -1,0 +1,13 @@
+package com.lighthouse.domain.usecase
+
+import com.lighthouse.domain.repository.GifticonRepository
+import javax.inject.Inject
+
+class RemoveGifticonUseCase @Inject constructor(
+    private val gifticonRepository: GifticonRepository
+) {
+
+    suspend operator fun invoke(gifticonId: String) {
+        gifticonRepository.removeGifticon(gifticonId)
+    }
+}

--- a/presentation/src/main/java/com/lighthouse/presentation/extension/KotlinExtention.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/extension/KotlinExtention.kt
@@ -14,6 +14,16 @@ val Int.dp
         TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, this.toFloat(), dm)
     } ?: 0f
 
+val Int.dpToPx
+    get() = Resources.getSystem().displayMetrics?.let { dm ->
+        this * dm.density
+    } ?: 0f
+
+val Float.dpToPx
+    get() = Resources.getSystem().displayMetrics?.let { dm ->
+        this * dm.density
+    } ?: 0f
+
 fun Int.toConcurrency(context: Context, useUnit: Boolean = true): String {
     val format = context.resources.getString(R.string.all_concurrency_format)
     val formattedNumber = DecimalFormat(format).format(this)

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/GifticonListViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/GifticonListViewModel.kt
@@ -7,6 +7,8 @@ import com.lighthouse.domain.model.DbResult
 import com.lighthouse.domain.model.Gifticon
 import com.lighthouse.domain.usecase.GetAllBrandsUseCase
 import com.lighthouse.domain.usecase.GetFilteredGifticonsUseCase
+import com.lighthouse.domain.usecase.RemoveGifticonUseCase
+import com.lighthouse.domain.usecase.UseGifticonUseCase
 import com.lighthouse.domain.util.isExpired
 import com.lighthouse.presentation.mapper.toDomain
 import com.lighthouse.presentation.model.GifticonSortBy
@@ -27,7 +29,9 @@ import javax.inject.Inject
 @HiltViewModel
 class GifticonListViewModel @Inject constructor(
     getAllBrandsUseCase: GetAllBrandsUseCase,
-    private val getFilteredGifticonsUseCase: GetFilteredGifticonsUseCase
+    private val getFilteredGifticonsUseCase: GetFilteredGifticonsUseCase,
+    private val useGifticonUseCase: UseGifticonUseCase,
+    private val removeGifticonUseCase: RemoveGifticonUseCase
 ) : ViewModel() {
 
     private val filter = MutableStateFlow(setOf<String>())
@@ -93,7 +97,6 @@ class GifticonListViewModel @Inject constructor(
                 )
             }
             is DbResult.Loading -> {
-                // TODO Shimmer UI
                 val gifticons = gifticons.value.let {
                     if (it is DbResult.Success) it.data else emptyList()
                 }
@@ -134,6 +137,18 @@ class GifticonListViewModel @Inject constructor(
 
     fun clearFilter() {
         filter.value = emptySet()
+    }
+
+    fun completeUsage(gifticon: Gifticon) {
+        viewModelScope.launch {
+            useGifticonUseCase(gifticon.id)
+        }
+    }
+
+    fun removeGifticon(gifticon: Gifticon) {
+        viewModelScope.launch {
+            removeGifticonUseCase(gifticon.id)
+        }
     }
 
     fun sort(newSortBy: GifticonSortBy) {

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/BrandChip.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/BrandChip.kt
@@ -205,7 +205,7 @@ fun BrandChip(
         },
         modifier = modifier.wrapContentWidth(),
         colors = ChipDefaults.filterChipColors(
-            backgroundColor = MaterialTheme.colors.onSurface.copy(alpha = 0.2f),
+            backgroundColor = MaterialTheme.colors.onSurface.copy(alpha = 0.1f),
             contentColor = MaterialTheme.colors.onSurface,
             selectedBackgroundColor = MaterialTheme.colors.primary,
             selectedContentColor = Color.White

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonList.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonList.kt
@@ -1,7 +1,9 @@
 package com.lighthouse.presentation.ui.gifticonlist.component
 
 import android.content.Intent
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,16 +15,24 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.FractionalThreshold
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.rememberSwipeableState
+import androidx.compose.material.swipeable
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -31,15 +41,19 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.google.accompanist.placeholder.PlaceholderHighlight
 import com.google.accompanist.placeholder.material.placeholder
 import com.google.accompanist.placeholder.material.shimmer
 import com.lighthouse.domain.model.Gifticon
 import com.lighthouse.domain.util.isExpired
 import com.lighthouse.presentation.R
+import com.lighthouse.presentation.extension.dpToPx
 import com.lighthouse.presentation.extension.toConcurrency
 import com.lighthouse.presentation.extension.toDday
 import com.lighthouse.presentation.extension.toExpireDate
@@ -47,9 +61,11 @@ import com.lighthouse.presentation.extra.Extras
 import com.lighthouse.presentation.ui.detailgifticon.GifticonDetailActivity
 import com.skydoves.landscapist.ImageOptions
 import com.skydoves.landscapist.glide.GlideImage
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
 
 @Composable
-fun GifticonList(gifticons: List<Gifticon>, modifier: Modifier = Modifier) {
+fun GifticonList(gifticons: List<Gifticon>, modifier: Modifier = Modifier, onDelete: (Gifticon) -> Unit = {}) {
     LazyColumn(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         modifier = modifier,
@@ -63,89 +79,148 @@ fun GifticonList(gifticons: List<Gifticon>, modifier: Modifier = Modifier) {
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
-fun GifticonItem(gifticon: Gifticon) {
+fun GifticonItem(gifticon: Gifticon, onUse: (Gifticon) -> Unit = {}, onDelete: (Gifticon) -> Unit = {}) {
     val context = LocalContext.current
     val cornerSize = 8.dp
 
-    Card(
+    val swipeableState = rememberSwipeableState(initialValue = 0)
+    val scope = rememberCoroutineScope()
+
+    Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(130.dp),
-        shape = MaterialTheme.shapes.medium.copy(CornerSize(cornerSize)),
-        onClick = {
-            context.startActivity(
-                Intent(context, GifticonDetailActivity::class.java).apply {
-                    putExtra(Extras.KEY_GIFTICON_ID, gifticon.id)
+            .wrapContentHeight()
+            .clip(RoundedCornerShape(cornerSize))
+            .swipeable(
+                state = swipeableState,
+                anchors = mapOf(
+                    0f to 0,
+                    -(100f.dpToPx) to 1,
+                    (100f.dpToPx) to 2
+                ),
+                thresholds = { _, _ ->
+                    FractionalThreshold(0.3f)
+                },
+                orientation = Orientation.Horizontal
+            )
+            .background(if (swipeableState.offset.value < 0) colorResource(id = R.color.point_green_dark) else Color.Red)
+    ) {
+        TextButton(
+            onClick = {
+                onDelete(gifticon)
+                scope.launch {
+                    swipeableState.animateTo(0, tween(600, 0))
                 }
+            },
+            modifier = Modifier.align(Alignment.CenterStart).padding(start = 20.dp).wrapContentWidth()
+        ) {
+            Text(
+                text = stringResource(id = R.string.all_remove),
+                style = MaterialTheme.typography.button.copy(fontSize = 16.sp),
+                color = Color.White,
+                fontWeight = FontWeight.SemiBold
             )
         }
-    ) {
-        Row {
-            GlideImage(
-                imageModel = { context.getFileStreamPath(gifticon.croppedPath) },
-                imageOptions = ImageOptions(
-                    contentScale = ContentScale.Crop,
-                    contentDescription = stringResource(R.string.gifticon_product_image),
-                    alignment = Alignment.Center
-                ),
-                modifier = Modifier
-                    .fillMaxHeight()
-                    .clip(RoundedCornerShape(topStart = cornerSize, bottomStart = cornerSize))
-                    .aspectRatio(1f)
-                    .align(Alignment.CenterVertically)
+        TextButton(
+            onClick = {
+                onUse(gifticon)
+                scope.launch {
+                    swipeableState.animateTo(0, tween(600, 0))
+                }
+            },
+            modifier = Modifier.align(Alignment.CenterEnd).padding(end = 20.dp).wrapContentWidth()
+        ) {
+            Text(
+                text = stringResource(id = R.string.gifticon_list_use_complete),
+                style = MaterialTheme.typography.button.copy(fontSize = 16.sp),
+                color = Color.White,
+                fontWeight = FontWeight.SemiBold
             )
-            Box(
-                modifier = Modifier.fillMaxSize()
-            ) {
-                Text(
-                    text = gifticon.expireAt.toDday(context),
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(cornerSize))
-                        .background(
-                            if (gifticon.expireAt.isExpired()) {
-                                Color.Gray
-                            } else {
-                                MaterialTheme.colors.primary
-                            }
-                        )
-                        .padding(horizontal = 16.dp, vertical = 8.dp)
-                        .align(Alignment.TopEnd),
-                    color = Color.White,
-                    style = MaterialTheme.typography.caption
+        }
+
+        Card(
+            modifier = Modifier
+                .offset {
+                    IntOffset(swipeableState.offset.value.roundToInt(), 0)
+                }
+                .fillMaxWidth()
+                .height(130.dp),
+            shape = MaterialTheme.shapes.medium.copy(CornerSize(cornerSize)),
+            onClick = {
+                context.startActivity(
+                    Intent(context, GifticonDetailActivity::class.java).apply {
+                        putExtra(Extras.KEY_GIFTICON_ID, gifticon.id)
+                    }
                 )
-                Text(
-                    text = gifticon.expireAt.toExpireDate(context),
+            }
+        ) {
+            Row {
+                GlideImage(
+                    imageModel = { context.getFileStreamPath(gifticon.croppedPath) },
+                    imageOptions = ImageOptions(
+                        contentScale = ContentScale.Crop,
+                        contentDescription = stringResource(R.string.gifticon_product_image),
+                        alignment = Alignment.Center
+                    ),
                     modifier = Modifier
-                        .align(Alignment.BottomEnd)
-                        .padding(bottom = 16.dp, end = 16.dp),
-                    style = MaterialTheme.typography.body2,
-                    color = MaterialTheme.colors.onSurface.copy(alpha = 0.7f)
+                        .fillMaxHeight()
+                        .clip(RoundedCornerShape(topStart = cornerSize, bottomStart = cornerSize))
+                        .aspectRatio(1f)
+                        .align(Alignment.CenterVertically)
                 )
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(horizontal = 16.dp, vertical = 8.dp),
-                    verticalArrangement = Arrangement.Center
+                Box(
+                    modifier = Modifier.fillMaxSize().background(MaterialTheme.colors.surface)
                 ) {
                     Text(
-                        text = gifticon.brand,
+                        text = gifticon.expireAt.toDday(context),
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(cornerSize))
+                            .background(
+                                if (gifticon.expireAt.isExpired()) {
+                                    Color.Gray
+                                } else {
+                                    MaterialTheme.colors.primary
+                                }
+                            )
+                            .padding(horizontal = 16.dp, vertical = 8.dp)
+                            .align(Alignment.TopEnd),
+                        color = Color.White,
+                        style = MaterialTheme.typography.caption
+                    )
+                    Text(
+                        text = gifticon.expireAt.toExpireDate(context),
+                        modifier = Modifier
+                            .align(Alignment.BottomEnd)
+                            .padding(bottom = 16.dp, end = 16.dp),
                         style = MaterialTheme.typography.body2,
                         color = MaterialTheme.colors.onSurface.copy(alpha = 0.7f)
                     )
-                    Text(
-                        text = gifticon.name,
-                        maxLines = 1,
-                        style = MaterialTheme.typography.body1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                    if (gifticon.isCashCard) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                        verticalArrangement = Arrangement.Center
+                    ) {
                         Text(
-                            modifier = Modifier.padding(top = 4.dp),
-                            text = gifticon.balance.toConcurrency(context, true),
-                            color = colorResource(R.color.beep_pink)
+                            text = gifticon.brand,
+                            style = MaterialTheme.typography.body2,
+                            color = MaterialTheme.colors.onSurface.copy(alpha = 0.7f)
                         )
-                    } else {
-                        Spacer(Modifier.height(16.dp))
+                        Text(
+                            text = gifticon.name,
+                            maxLines = 1,
+                            style = MaterialTheme.typography.body1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        if (gifticon.isCashCard) {
+                            Text(
+                                modifier = Modifier.padding(top = 4.dp),
+                                text = gifticon.balance.toConcurrency(context, true),
+                                color = colorResource(R.color.beep_pink)
+                            )
+                        } else {
+                            Spacer(Modifier.height(16.dp))
+                        }
                     }
                 }
             }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonList.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonList.kt
@@ -65,21 +65,30 @@ import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
 @Composable
-fun GifticonList(gifticons: List<Gifticon>, modifier: Modifier = Modifier, onDelete: (Gifticon) -> Unit = {}) {
+fun GifticonList(
+    gifticons: List<Gifticon>,
+    modifier: Modifier = Modifier,
+    onUse: (Gifticon) -> Unit = {},
+    onRemove: (Gifticon) -> Unit = {}
+) {
     LazyColumn(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         modifier = modifier,
         contentPadding = PaddingValues(vertical = 36.dp)
     ) {
-        items(gifticons) { gifticon ->
-            GifticonItem(gifticon = gifticon)
+        items(gifticons, key = { it.id }) { gifticon ->
+            GifticonItem(
+                gifticon = gifticon,
+                onUse = { onUse(it) },
+                onRemove = { onRemove(it) }
+            )
         }
     }
 }
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
-fun GifticonItem(gifticon: Gifticon, onUse: (Gifticon) -> Unit = {}, onDelete: (Gifticon) -> Unit = {}) {
+fun GifticonItem(gifticon: Gifticon, onUse: (Gifticon) -> Unit = {}, onRemove: (Gifticon) -> Unit = {}) {
     val context = LocalContext.current
     val cornerSize = 8.dp
 
@@ -107,7 +116,7 @@ fun GifticonItem(gifticon: Gifticon, onUse: (Gifticon) -> Unit = {}, onDelete: (
     ) {
         TextButton(
             onClick = {
-                onDelete(gifticon)
+                onRemove(gifticon)
                 scope.launch {
                     swipeableState.animateTo(0, tween(600, 0))
                 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonListScreen.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonListScreen.kt
@@ -54,7 +54,13 @@ fun GifticonListScreen(
             } else {
                 GifticonList(
                     gifticons = viewState.gifticons,
-                    Modifier.padding(top = 8.dp)
+                    Modifier.padding(top = 8.dp),
+                    onUse = {
+                        viewModel.completeUsage(it)
+                    },
+                    onRemove = {
+                        viewModel.removeGifticon(it)
+                    }
                 )
             }
         }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonListScreen.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonListScreen.kt
@@ -1,18 +1,32 @@
 package com.lighthouse.presentation.ui.gifticonlist.component
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.AlertDialog
 import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.lighthouse.domain.model.Gifticon
+import com.lighthouse.presentation.R
 import com.lighthouse.presentation.ui.gifticonlist.GifticonListViewModel
 
 @OptIn(ExperimentalLifecycleComposeApi::class)
@@ -22,6 +36,7 @@ fun GifticonListScreen(
     viewModel: GifticonListViewModel = viewModel()
 ) {
     val viewState by viewModel.state.collectAsStateWithLifecycle()
+    var removeGifticonDialogState by remember { mutableStateOf<Gifticon?>(null) }
 
     Surface(
         modifier = modifier
@@ -59,7 +74,7 @@ fun GifticonListScreen(
                         viewModel.completeUsage(it)
                     },
                     onRemove = {
-                        viewModel.removeGifticon(it)
+                        removeGifticonDialogState = it
                     }
                 )
             }
@@ -82,5 +97,31 @@ fun GifticonListScreen(
                 }
             )
         }
+    }
+    if (removeGifticonDialogState != null) {
+        AlertDialog(
+            onDismissRequest = { removeGifticonDialogState = null },
+            title = {
+                Row {
+                    Image(
+                        imageVector = Icons.Default.Warning,
+                        contentDescription = null,
+                        colorFilter = ColorFilter.tint(Color.Red)
+                    )
+                    Text(stringResource(R.string.gifticon_list_remove_gifticon_dialog_title))
+                }
+            },
+            text = { Text(stringResource(R.string.gifticon_list_remove_gifticon_dialog_message)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.removeGifticon(gifticon = removeGifticonDialogState ?: return@TextButton)
+                        removeGifticonDialogState = null
+                    }
+                ) {
+                    Text(stringResource(R.string.gifticon_list_remove_gifticon_dialog_remove_button))
+                }
+            }
+        )
     }
 }

--- a/presentation/src/main/res/values/colors.xml
+++ b/presentation/src/main/res/values/colors.xml
@@ -19,5 +19,6 @@
 
     <color name="yellow">#FEDD16</color>
     <color name="point_green">#06DA79</color>
+    <color name="point_green_dark">#0EBA75</color>
     <color name="widget_background">#FFFFFFFF</color>
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="all_prev">이전</string>
     <string name="all_close_button">닫기</string>
     <string name="all_not_use">사용 안 함</string>
+    <string name="all_remove">제거</string>
 
     <string name="confirmation_ok">확인</string>
     <string name="confirmation_title">권한 필요</string>
@@ -228,6 +229,7 @@
     <string name="gifticon_list_toolbar_dropdown_icon_description">드롭다운 아이콘</string>
     <string name="gifticon_list_show_all_brand_chips_button">브랜드 전체 보기 버튼</string>
     <string name="gifticon_list_brands_dialog_show_expired_gifticon_option">만료된 기프티콘 표시</string>
+    <string name="gifticon_list_use_complete">사용\n처리</string>
     <string name="gifticon_product_image">기프티콘 상품 이미지</string>
 
     <string name="home_near_title">근처에서 사용할 수 있어요</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -230,6 +230,9 @@
     <string name="gifticon_list_show_all_brand_chips_button">브랜드 전체 보기 버튼</string>
     <string name="gifticon_list_brands_dialog_show_expired_gifticon_option">만료된 기프티콘 표시</string>
     <string name="gifticon_list_use_complete">사용\n처리</string>
+    <string name="gifticon_list_remove_gifticon_dialog_title">기프티콘을 삭제합니다</string>
+    <string name="gifticon_list_remove_gifticon_dialog_message">삭제하면 복구할 수 없습니다. 정말 삭제하시겠습니까?</string>
+    <string name="gifticon_list_remove_gifticon_dialog_remove_button">삭제하기</string>
     <string name="gifticon_product_image">기프티콘 상품 이미지</string>
 
     <string name="home_near_title">근처에서 사용할 수 있어요</string>
@@ -273,6 +276,4 @@
 
     <string name="map_back_description">네이버 맵에서 뒤로가기 버튼</string>
     <string name="map_back_button">맵에서 뒤로가기 버튼</string>
-
-
 </resources>


### PR DESCRIPTION
resolved: #215

## 작업 내용

- 기프티콘 목록에서 스와이프로 밀 수 있음
- 왼쪽에 삭제, 오른쪽에 사용 처리 버튼이 존재
- 사용 처리를 누르면 목록에서 사라지고 사용된 기프티콘 화면에서 볼 수 있음
- 삭제 버튼을 누르면 다이얼로그로 물어본 후 "삭제하기" 버튼을 누르면 삭제됨

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정

## 동작 화면

<img src="https://user-images.githubusercontent.com/44221447/206906634-acaf8129-df85-4b21-a545-708ade9aa741.gif" width="33%" />

<img src="https://user-images.githubusercontent.com/44221447/206906636-5432ca36-6d36-4628-a9ce-19f2aa197803.gif" width="33%" />
