### PR TITLE
빈 설정 항목 숨기기

### DIFF
--- a/presentation/src/main/res/layout/fragment_setting_main.xml
+++ b/presentation/src/main/res/layout/fragment_setting_main.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
@@ -218,7 +219,9 @@
             android:foreground="?attr/selectableItemBackground"
             android:paddingVertical="16dp"
             android:text="@string/setting_coffee"
-            app:layout_constraintTop_toBottomOf="@+id/tv_divider_etc" />
+            android:visibility="gone"
+            app:layout_constraintTop_toBottomOf="@+id/tv_divider_etc"
+            tools:layout_editor_absoluteX="0dp" />
 
         <ImageView
             android:id="@+id/iv_arrow_forward_coffee"
@@ -238,6 +241,7 @@
             android:foreground="?attr/selectableItemBackground"
             android:paddingVertical="16dp"
             android:text="@string/setting_terms_of_use"
+            android:visibility="gone"
             app:layout_constraintTop_toBottomOf="@+id/tv_coffee" />
 
         <ImageView
@@ -245,6 +249,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:contentDescription="@string/setting_terms_of_use"
+            android:visibility="gone"
             android:src="@drawable/ic_arrow_forward"
             app:layout_constraintBottom_toBottomOf="@+id/tv_terms_of_use"
             app:layout_constraintEnd_toEndOf="@+id/gl_arrow"
@@ -258,6 +263,7 @@
             android:foreground="?attr/selectableItemBackground"
             android:paddingVertical="16dp"
             android:text="@string/setting_personal_info_policy"
+            android:visibility="gone"
             app:layout_constraintTop_toBottomOf="@+id/tv_terms_of_use" />
 
         <ImageView
@@ -266,6 +272,7 @@
             android:layout_height="wrap_content"
             android:contentDescription="@string/setting_personal_info_policy"
             android:src="@drawable/ic_arrow_forward"
+            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="@+id/tv_personal_info_policy"
             app:layout_constraintEnd_toEndOf="@+id/gl_arrow"
             app:layout_constraintTop_toTopOf="@+id/tv_personal_info_policy" />


### PR DESCRIPTION
## 작업 내용

- 안에 내용 없는 설정 숨기기만 했습니다

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정

## 버그

- 사용한 기프티콘이 있는 경우 사용한 기프티콘 탭에서 앱이 종료되는데, 이것은 명석님 PR에서 고쳐져서 올라갈 예정입니다.
- 합쳐진 후에도 한번 확인 필요