### PR TITLE
빈 홈 화면일 때 ripple 효과 다른 버튼과 동일하게 맞추는 작업 진행

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,15 +1,15 @@
 plugins {
-    id("com.android.application") version "7.3.1" apply false
-    id("com.android.library") version "7.3.1" apply false
-    id("org.jetbrains.kotlin.android") version "1.7.20" apply false
-    id("org.jetbrains.kotlin.jvm") version "1.7.20" apply false
+    id("com.android.application") version "7.4.1" apply false
+    id("com.android.library") version "7.4.1" apply false
+    id("org.jetbrains.kotlin.android") version "1.8.0" apply false
+    id("org.jetbrains.kotlin.jvm") version "1.8.0" apply false
     id("com.google.dagger.hilt.android") version "2.44" apply false
 }
 
 buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:7.2.0")
-        classpath("com.google.gms:google-services:4.3.14")
+        classpath("com.google.gms:google-services:4.3.15")
         classpath("com.google.firebase:firebase-crashlytics-gradle:2.9.2")
         classpath("com.google.android.gms:oss-licenses-plugin:0.10.6")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 buildscript {
     dependencies {
-        classpath("com.android.tools.build:gradle:7.2.0")
+        classpath("com.android.tools.build:gradle:7.4.1")
         classpath("com.google.gms:google-services:4.3.15")
         classpath("com.google.firebase:firebase-crashlytics-gradle:2.9.2")
         classpath("com.google.android.gms:oss-licenses-plugin:0.10.6")

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -52,7 +52,7 @@ object Versions {
     const val DATASTORE = "1.1.0-alpha01"
 
     const val APP_COMPAT_THEME = "0.25.1" // 컴포즈에서 AppTheme 을 사용
-    const val KOTLIN_COMPILER_EXTENSION = "1.3.2"
+    const val KOTLIN_COMPILER_EXTENSION = "1.4.0"
     const val COMPOSE_BOM = "2022.10.00"
     const val COMPOSE_ACTIVITIES = "1.5.1"
     const val COMPOSE_VIEWMODEL = "2.5.1"

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -23,8 +23,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     kotlinOptions {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Nov 07 15:45:14 KST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/presentation/src/main/java/com/lighthouse/presentation/background/NotificationHelper.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/background/NotificationHelper.kt
@@ -1,5 +1,6 @@
 package com.lighthouse.presentation.background
 
+import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -46,6 +47,7 @@ class NotificationHelper @Inject constructor(
         }
     }
 
+    @SuppressLint("MissingPermission")
     fun applyNotification(gifticon: Gifticon, remainDays: Int) {
         val intent = Intent(context, GifticonDetailActivity::class.java).apply {
             putExtra(Extras.KEY_GIFTICON_ID, gifticon.id)

--- a/presentation/src/main/res/layout/fragment_home_empty.xml
+++ b/presentation/src/main/res/layout/fragment_home_empty.xml
@@ -51,18 +51,18 @@
             app:lottie_loop="true"
             app:lottie_rawRes="@raw/lottie_not_found" />
 
-        <Button
+        <TextView
             android:id="@+id/tv_register"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:layout_marginBottom="16dp"
-            android:background="?attr/colorPrimary"
+            android:background="@drawable/ripple_primary_corner_4"
             android:gravity="center"
             android:onClickListener="@{() -> vm.gotoAddGifticon()}"
             android:padding="12dp"
             android:text="@string/add_gifticon_register"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Button"
             android:textColor="?attr/colorOnPrimary"
             android:textStyle="bold"
             app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
resolved: #279 

## 작업 내용

- empty home일 때 버튼 ripple 효과가 다른 버튼과 달라서 동일하게 맞추는 작업 진행

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정

## 동작 화면

https://user-images.githubusercontent.com/53300830/216261304-41c81aba-8987-42fa-942e-cdbe38c5a981.mp4


