### PR TITLE
home/map 기프티콘 데이터들 전부 local에서 갖고 오게 변경

### DIFF
--- a/data/src/main/java/com/lighthouse/database/dao/GifticonDao.kt
+++ b/data/src/main/java/com/lighthouse/database/dao/GifticonDao.kt
@@ -43,7 +43,10 @@ interface GifticonDao {
     fun getFilteredGifticons(userId: String, filters: Set<String>): Flow<List<GifticonEntity>>
 
     @Query("SELECT * FROM $GIFTICON_TABLE WHERE user_id = :userId AND is_used = 0 AND UPPER(brand) IN(:filters) ORDER BY expire_at")
-    fun getFilteredGifticonsSortByDeadline(userId: String, filters: Set<String>): Flow<List<GifticonEntity>>
+    fun getFilteredGifticonsSortByDeadline(
+        userId: String,
+        filters: Set<String>
+    ): Flow<List<GifticonEntity>>
 
     @Query(
         "SELECT * FROM $GIFTICON_TABLE " +
@@ -145,7 +148,17 @@ interface GifticonDao {
     @Transaction
     suspend fun updateGifticonWithCropTransaction(gifticonWithCrop: GifticonWithCrop) {
         with(gifticonWithCrop) {
-            updateGifticon(id, croppedUri, name, brand, expireAt, barcode, isCashCard, balance, memo)
+            updateGifticon(
+                id,
+                croppedUri,
+                name,
+                brand,
+                expireAt,
+                barcode,
+                isCashCard,
+                balance,
+                memo
+            )
             updateGifticonCrop(id, croppedRect)
         }
     }
@@ -190,4 +203,7 @@ interface GifticonDao {
 
     @Query("UPDATE $GIFTICON_TABLE SET user_id = :newUserId WHERE user_id = :oldUserId")
     suspend fun moveUserIdGifticon(oldUserId: String, newUserId: String)
+
+    @Query("SELECT DISTINCT brand FROM $GIFTICON_TABLE WHERE user_id = :userId AND expire_at >= :time AND is_used = 0")
+    fun getGifticonBrands(userId: String, time: Date): Flow<List<String>>
 }

--- a/data/src/main/java/com/lighthouse/database/dao/GifticonDao.kt
+++ b/data/src/main/java/com/lighthouse/database/dao/GifticonDao.kt
@@ -195,7 +195,10 @@ interface GifticonDao {
     @Query("SELECT * FROM $GIFTICON_TABLE WHERE brand =:brand")
     fun getGifticonByBrand(brand: String): Flow<List<GifticonEntity>>
 
-    @Query("SELECT EXISTS (SELECT * FROM $GIFTICON_TABLE WHERE expire_at >= :time AND is_used = 0 AND user_id = :userId)")
+    @Query(
+        "SELECT EXISTS (SELECT * FROM $GIFTICON_TABLE " +
+            "WHERE expire_at >= :time AND is_used = 0 AND user_id = :userId)"
+    )
     fun hasUsableGifticon(userId: String, time: Date): Flow<Boolean>
 
     @Query("SELECT EXISTS(SELECT 1 from $GIFTICON_TABLE WHERE LOWER(brand)=LOWER(:brand) LIMIT 1)")
@@ -207,12 +210,18 @@ interface GifticonDao {
     /**
      * 오늘 날짜를 기준으로 사용 가능한 기프티콘의 브랜드명 갖고 오기
      */
-    @Query("SELECT DISTINCT brand FROM $GIFTICON_TABLE WHERE user_id = :userId AND expire_at >= :time AND is_used = 0")
+    @Query(
+        "SELECT DISTINCT brand FROM $GIFTICON_TABLE " +
+            "WHERE user_id = :userId AND expire_at >= :time AND is_used = 0"
+    )
     fun getGifticonBrands(userId: String, time: Date): Flow<List<String>>
 
     /**
      * 사용 가능한 기프티콘 중에서 count 만큼만 갖고 오기
      */
-    @Query("SELECT * FROM $GIFTICON_TABLE WHERE user_id = :userId AND expire_at >= :time AND is_used = 0 LIMIT :count")
+    @Query(
+        "SELECT * FROM $GIFTICON_TABLE " +
+            "WHERE user_id = :userId AND expire_at >= :time AND is_used = 0 LIMIT :count"
+    )
     fun getSomeGifticons(userId: String, time: Date, count: Int): Flow<List<GifticonEntity>>
 }

--- a/data/src/main/java/com/lighthouse/database/dao/GifticonDao.kt
+++ b/data/src/main/java/com/lighthouse/database/dao/GifticonDao.kt
@@ -204,6 +204,15 @@ interface GifticonDao {
     @Query("UPDATE $GIFTICON_TABLE SET user_id = :newUserId WHERE user_id = :oldUserId")
     suspend fun moveUserIdGifticon(oldUserId: String, newUserId: String)
 
+    /**
+     * 오늘 날짜를 기준으로 사용 가능한 기프티콘의 브랜드명 갖고 오기
+     */
     @Query("SELECT DISTINCT brand FROM $GIFTICON_TABLE WHERE user_id = :userId AND expire_at >= :time AND is_used = 0")
     fun getGifticonBrands(userId: String, time: Date): Flow<List<String>>
+
+    /**
+     * 사용 가능한 기프티콘 중에서 count 만큼만 갖고 오기
+     */
+    @Query("SELECT * FROM $GIFTICON_TABLE WHERE user_id = :userId AND expire_at >= :time AND is_used = 0 LIMIT :count")
+    fun getSomeGifticons(userId: String, time: Date, count: Int): Flow<List<GifticonEntity>>
 }

--- a/data/src/main/java/com/lighthouse/datasource/gifticon/GifticonLocalDataSource.kt
+++ b/data/src/main/java/com/lighthouse/datasource/gifticon/GifticonLocalDataSource.kt
@@ -35,4 +35,5 @@ interface GifticonLocalDataSource {
     suspend fun hasGifticonBrand(brand: String): Boolean
     suspend fun moveUserIdGifticon(oldUserId: String, newUserId: String)
     fun getGifticonBrands(userId: String): Flow<List<String>>
+    fun getSomeGifticons(userId: String, count: Int): Flow<List<GifticonEntity>>
 }

--- a/data/src/main/java/com/lighthouse/datasource/gifticon/GifticonLocalDataSource.kt
+++ b/data/src/main/java/com/lighthouse/datasource/gifticon/GifticonLocalDataSource.kt
@@ -34,4 +34,5 @@ interface GifticonLocalDataSource {
     fun getUsableGifticons(userId: String): Flow<List<GifticonEntity>>
     suspend fun hasGifticonBrand(brand: String): Boolean
     suspend fun moveUserIdGifticon(oldUserId: String, newUserId: String)
+    fun getGifticonBrands(userId: String): Flow<List<String>>
 }

--- a/data/src/main/java/com/lighthouse/datasource/gifticon/GifticonLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/lighthouse/datasource/gifticon/GifticonLocalDataSourceImpl.kt
@@ -143,4 +143,8 @@ class GifticonLocalDataSourceImpl @Inject constructor(
     override fun getGifticonBrands(userId: String): Flow<List<String>> {
         return gifticonDao.getGifticonBrands(userId, today)
     }
+
+    override fun getSomeGifticons(userId: String, count: Int): Flow<List<GifticonEntity>> {
+        return gifticonDao.getSomeGifticons(userId, today, count)
+    }
 }

--- a/data/src/main/java/com/lighthouse/datasource/gifticon/GifticonLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/lighthouse/datasource/gifticon/GifticonLocalDataSourceImpl.kt
@@ -42,7 +42,11 @@ class GifticonLocalDataSourceImpl @Inject constructor(
         }
     }
 
-    override fun getFilteredGifticons(userId: String, filter: Set<String>, sortBy: SortBy): Flow<List<Gifticon>> {
+    override fun getFilteredGifticons(
+        userId: String,
+        filter: Set<String>,
+        sortBy: SortBy
+    ): Flow<List<Gifticon>> {
         val upperFilter = filter.map { it.uppercase() }.toSet()
         val gifticons = when (sortBy) {
             SortBy.DEADLINE -> gifticonDao.getFilteredGifticonsSortByDeadline(userId, upperFilter)
@@ -85,8 +89,15 @@ class GifticonLocalDataSourceImpl @Inject constructor(
         gifticonDao.useGifticonTransaction(usageHistory.toUsageHistoryEntity(gifticonId))
     }
 
-    override suspend fun useCashCardGifticon(gifticonId: String, amount: Int, usageHistory: UsageHistory) {
-        gifticonDao.useCashCardGifticonTransaction(amount, usageHistory.toUsageHistoryEntity(gifticonId))
+    override suspend fun useCashCardGifticon(
+        gifticonId: String,
+        amount: Int,
+        usageHistory: UsageHistory
+    ) {
+        gifticonDao.useCashCardGifticonTransaction(
+            amount,
+            usageHistory.toUsageHistoryEntity(gifticonId)
+        )
     }
 
     override suspend fun unUseGifticon(gifticonId: String) {
@@ -127,5 +138,9 @@ class GifticonLocalDataSourceImpl @Inject constructor(
 
     override suspend fun moveUserIdGifticon(oldUserId: String, newUserId: String) {
         gifticonDao.moveUserIdGifticon(oldUserId, newUserId)
+    }
+
+    override fun getGifticonBrands(userId: String): Flow<List<String>> {
+        return gifticonDao.getGifticonBrands(userId, today)
     }
 }

--- a/data/src/main/java/com/lighthouse/repository/GifticonRepositoryImpl.kt
+++ b/data/src/main/java/com/lighthouse/repository/GifticonRepositoryImpl.kt
@@ -35,14 +35,15 @@ class GifticonRepositoryImpl @Inject constructor(
         emit(DbResult.Failure(e))
     }
 
-    override fun getAllGifticons(userId: String, sortBy: SortBy): Flow<DbResult<List<Gifticon>>> = flow {
-        emit(DbResult.Loading)
-        gifticonLocalDataSource.getAllGifticons(userId, sortBy).collect {
-            emit(DbResult.Success(it))
+    override fun getAllGifticons(userId: String, sortBy: SortBy): Flow<DbResult<List<Gifticon>>> =
+        flow {
+            emit(DbResult.Loading)
+            gifticonLocalDataSource.getAllGifticons(userId, sortBy).collect {
+                emit(DbResult.Success(it))
+            }
+        }.catch { e ->
+            emit(DbResult.Failure(e))
         }
-    }.catch { e ->
-        emit(DbResult.Failure(e))
-    }
 
     override fun getAllUsedGifticons(userId: String): Flow<DbResult<List<Gifticon>>> = flow {
         emit(DbResult.Loading)
@@ -66,14 +67,15 @@ class GifticonRepositoryImpl @Inject constructor(
         emit(DbResult.Failure(e))
     }
 
-    override fun getAllBrands(userId: String, filterExpired: Boolean): Flow<DbResult<List<Brand>>> = flow {
-        emit(DbResult.Loading)
-        gifticonLocalDataSource.getAllBrands(userId, filterExpired).collect {
-            emit(DbResult.Success(it))
+    override fun getAllBrands(userId: String, filterExpired: Boolean): Flow<DbResult<List<Brand>>> =
+        flow {
+            emit(DbResult.Loading)
+            gifticonLocalDataSource.getAllBrands(userId, filterExpired).collect {
+                emit(DbResult.Success(it))
+            }
+        }.catch { e ->
+            emit(DbResult.Failure(e))
         }
-    }.catch { e ->
-        emit(DbResult.Failure(e))
-    }
 
     override suspend fun getGifticonCrop(userId: String, id: String): GifticonForUpdate? {
         return gifticonLocalDataSource.getGifticonCrop(userId, id)?.toDomain()
@@ -91,7 +93,10 @@ class GifticonRepositoryImpl @Inject constructor(
         gifticonLocalDataSource.updateGifticon(gifticonForUpdate.toEntity(croppedUri))
     }
 
-    override suspend fun saveGifticons(userId: String, gifticonForAdditions: List<GifticonForAddition>) {
+    override suspend fun saveGifticons(
+        userId: String,
+        gifticonForAdditions: List<GifticonForAddition>
+    ) {
         val newGifticons = gifticonForAdditions.map { gifticonForAddition ->
             val id = UUID.generate()
             var result: GifticonImageResult? = null
@@ -128,7 +133,11 @@ class GifticonRepositoryImpl @Inject constructor(
         gifticonLocalDataSource.useGifticon(gifticonId, usageHistory)
     }
 
-    override suspend fun useCashCardGifticon(gifticonId: String, amount: Int, usageHistory: UsageHistory) {
+    override suspend fun useCashCardGifticon(
+        gifticonId: String,
+        amount: Int,
+        usageHistory: UsageHistory
+    ) {
         gifticonLocalDataSource.useCashCardGifticon(gifticonId, amount, usageHistory)
     }
 
@@ -168,9 +177,22 @@ class GifticonRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun hasGifticonBrand(brand: String) = gifticonLocalDataSource.hasGifticonBrand(brand)
+    override suspend fun hasGifticonBrand(brand: String) =
+        gifticonLocalDataSource.hasGifticonBrand(brand)
 
     override suspend fun moveUserIdGifticon(oldUserId: String, newUserId: String) {
         gifticonLocalDataSource.moveUserIdGifticon(oldUserId, newUserId)
+    }
+
+    override fun getGifticonBrands(userId: String): Flow<DbResult<List<String>>> = flow {
+        emit(DbResult.Loading)
+
+        gifticonLocalDataSource.getGifticonBrands(userId).collect { brands ->
+            if (brands.isEmpty()) {
+                emit(DbResult.Empty)
+            } else {
+                emit(DbResult.Success(brands))
+            }
+        }
     }
 }

--- a/data/src/main/java/com/lighthouse/repository/GifticonRepositoryImpl.kt
+++ b/data/src/main/java/com/lighthouse/repository/GifticonRepositoryImpl.kt
@@ -195,4 +195,17 @@ class GifticonRepositoryImpl @Inject constructor(
             }
         }
     }
+
+    override fun getSomeGifticons(userId: String, count: Int): Flow<DbResult<List<Gifticon>>> =
+        flow {
+            emit(DbResult.Loading)
+
+            gifticonLocalDataSource.getSomeGifticons(userId, count).collect { gifticons ->
+                if (gifticons.isEmpty()) {
+                    emit(DbResult.Empty)
+                } else {
+                    emit(DbResult.Success(gifticons.map { it.toDomain() }))
+                }
+            }
+        }
 }

--- a/domain/src/main/java/com/lighthouse/domain/repository/GifticonRepository.kt
+++ b/domain/src/main/java/com/lighthouse/domain/repository/GifticonRepository.kt
@@ -34,6 +34,6 @@ interface GifticonRepository {
     fun hasUsableGifticon(userId: String): Flow<Boolean>
     fun getUsableGifticons(userId: String): Flow<DbResult<List<Gifticon>>>
     suspend fun hasGifticonBrand(brand: String): Boolean
-
     suspend fun moveUserIdGifticon(oldUserId: String, newUserId: String)
+    fun getGifticonBrands(userId: String): Flow<DbResult<List<String>>>
 }

--- a/domain/src/main/java/com/lighthouse/domain/repository/GifticonRepository.kt
+++ b/domain/src/main/java/com/lighthouse/domain/repository/GifticonRepository.kt
@@ -36,4 +36,5 @@ interface GifticonRepository {
     suspend fun hasGifticonBrand(brand: String): Boolean
     suspend fun moveUserIdGifticon(oldUserId: String, newUserId: String)
     fun getGifticonBrands(userId: String): Flow<DbResult<List<String>>>
+    fun getSomeGifticons(userId: String, count: Int): Flow<DbResult<List<Gifticon>>>
 }

--- a/domain/src/main/java/com/lighthouse/domain/usecase/GetGifticonsUseCase.kt
+++ b/domain/src/main/java/com/lighthouse/domain/usecase/GetGifticonsUseCase.kt
@@ -28,4 +28,8 @@ class GetGifticonsUseCase @Inject constructor(
     fun getGifticonBrands(): Flow<DbResult<List<String>>> {
         return gifticonRepository.getGifticonBrands(userId)
     }
+
+    fun getSomeGifticons(count: Int): Flow<DbResult<List<Gifticon>>> {
+        return gifticonRepository.getSomeGifticons(userId, count)
+    }
 }

--- a/domain/src/main/java/com/lighthouse/domain/usecase/GetGifticonsUseCase.kt
+++ b/domain/src/main/java/com/lighthouse/domain/usecase/GetGifticonsUseCase.kt
@@ -24,4 +24,8 @@ class GetGifticonsUseCase @Inject constructor(
     fun getUsedGifticons(): Flow<DbResult<List<Gifticon>>> {
         return gifticonRepository.getAllUsedGifticons(userId)
     }
+
+    fun getGifticonBrands(): Flow<DbResult<List<String>>> {
+        return gifticonRepository.getGifticonBrands(userId)
+    }
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/background/NotificationHelper.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/background/NotificationHelper.kt
@@ -1,5 +1,6 @@
 package com.lighthouse.presentation.background
 
+import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -46,6 +47,7 @@ class NotificationHelper @Inject constructor(
         }
     }
 
+    @SuppressLint("MissingPermission")
     fun applyNotification(gifticon: Gifticon, remainDays: Int) {
         val intent = Intent(context, GifticonDetailActivity::class.java).apply {
             putExtra(Extras.KEY_GIFTICON_ID, gifticon.id)

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/home/HomeViewModel.kt
@@ -47,7 +47,7 @@ class HomeViewModel @Inject constructor(
         if (brands is DbResult.Success) {
             emit(brands.data)
         }
-    }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList<String>())
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     private val gifticonsMap = gifticons.transform { gifticons ->
         if (gifticons is DbResult.Success) {

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/home/HomeViewModel.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -41,12 +40,10 @@ class HomeViewModel @Inject constructor(
     private val _eventFlow = MutableEventFlow<HomeEvent>()
     val eventFlow = _eventFlow.asEventFlow()
 
-    private val gifticons =
-        getGifticonUseCase.getUsableGifticons()
-            .stateIn(viewModelScope, SharingStarted.Eagerly, DbResult.Loading)
+    private val gifticons = getGifticonUseCase.getUsableGifticons()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, DbResult.Loading)
 
     private val allBrands = getGifticonUseCase.getGifticonBrands().transform { brands ->
-        Timber.tag("TAG").d("${javaClass.simpleName} allbrands -> $brands")
         if (brands is DbResult.Success) {
             emit(brands.data)
         }
@@ -59,16 +56,12 @@ class HomeViewModel @Inject constructor(
         }
     }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyMap())
 
-    val expiredGifticon = gifticons.transform { gifticons ->
-        if (gifticons is DbResult.Success) {
-            val data = gifticons.data.map {
-                it.toPresentation()
+    val expiredGifticon =
+        getGifticonUseCase.getSomeGifticons(EXPIRED_GIFTICON_LIST_MAX_SIZE).transform { gifticons ->
+            if (gifticons is DbResult.Success) {
+                emit(gifticons.data.map { it.toPresentation() })
             }
-            val gifticonSize =
-                if (data.size < EXPIRED_GIFTICON_LIST_MAX_SIZE) data.size else EXPIRED_GIFTICON_LIST_MAX_SIZE
-            emit(data.slice(0 until gifticonSize))
-        }
-    }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     private val _uiState: MutableEventFlow<UiState<Unit>> = MutableEventFlow()
     val uiState = _uiState.asEventFlow()
@@ -131,30 +124,30 @@ class HomeViewModel @Inject constructor(
             val x = location.longitude
             val y = location.latitude
 
-            getBrandPlaceInfosUseCase(allBrands.value, x, y, SEARCH_SIZE)
-                .mapCatching { brand -> brand.toPresentation() }
-                .onSuccess { brands ->
-                    nearBrandsInfo = brands
-                    _nearGifticons.value = nearBrandsInfo
-                        .distinctBy { it.brandLowerName }
-                        .mapNotNull { placeInfo ->
-                            gifticonsMap.value[placeInfo.brandLowerName]
-                                ?.first()
-                                ?.toPresentation(diffLocation(placeInfo.x, placeInfo.y, x, y))
-                        }
-                    when (_nearGifticons.value.isNullOrEmpty()) {
-                        true -> _uiState.emit(UiState.NotFoundResults)
-                        false -> _uiState.emit(UiState.Success(Unit))
+            getBrandPlaceInfosUseCase(
+                allBrands.value,
+                x,
+                y,
+                SEARCH_SIZE
+            ).mapCatching { brand -> brand.toPresentation() }.onSuccess { brands ->
+                nearBrandsInfo = brands
+                _nearGifticons.value =
+                    nearBrandsInfo.distinctBy { it.brandLowerName }.mapNotNull { placeInfo ->
+                        gifticonsMap.value[placeInfo.brandLowerName]?.first()
+                            ?.toPresentation(diffLocation(placeInfo.x, placeInfo.y, x, y))
                     }
+                when (_nearGifticons.value.isNullOrEmpty()) {
+                    true -> _uiState.emit(UiState.NotFoundResults)
+                    false -> _uiState.emit(UiState.Success(Unit))
                 }
-                .onFailure { throwable ->
-                    _uiState.emit(
-                        when (throwable) {
-                            BeepError.NetworkFailure -> UiState.NetworkFailure
-                            else -> UiState.Failure
-                        }
-                    )
-                }
+            }.onFailure { throwable ->
+                _uiState.emit(
+                    when (throwable) {
+                        BeepError.NetworkFailure -> UiState.NetworkFailure
+                        else -> UiState.Failure
+                    }
+                )
+            }
             isShimmer.value = false
         }
     }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/map/MapViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/map/MapViewModel.kt
@@ -64,9 +64,11 @@ class MapViewModel @Inject constructor(
         }
     }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
-    private val allBrands = allGifticons.transform { gifticons ->
-        emit(gifticons.map { it.brand.lowercase() }.distinct())
-    }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
+    private val allBrands = getGifticonUseCase.getGifticonBrands().transform { brands ->
+        if (brands is DbResult.Success) {
+            emit(brands.data)
+        }
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     private val _gifticonData = MutableStateFlow<List<GifticonUIModel>>(emptyList())
     val gifticonData = _gifticonData.asStateFlow()
@@ -117,7 +119,7 @@ class MapViewModel @Inject constructor(
         private set
 
     private var removeMarker = allBrands.transform {
-        val brands = it ?: return@transform
+        val brands = it
         val removeMarkers =
             markerHolder.filter { marker -> brands.contains(marker.captionText.lowercase()).not() }
         emit(removeMarkers)
@@ -184,7 +186,7 @@ class MapViewModel @Inject constructor(
                     updateGifticons()
                     return@collectLatest
                 }
-                val brands = allBrands.value ?: return@collectLatest
+                val brands = allBrands.value
 
                 _state.emit(UiState.Loading)
                 getBrandPlaceInfosUseCase(

--- a/presentation/src/main/res/layout/fragment_home_empty.xml
+++ b/presentation/src/main/res/layout/fragment_home_empty.xml
@@ -51,18 +51,18 @@
             app:lottie_loop="true"
             app:lottie_rawRes="@raw/lottie_not_found" />
 
-        <Button
+        <TextView
             android:id="@+id/tv_register"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:layout_marginBottom="16dp"
-            android:background="?attr/colorPrimary"
+            android:background="@drawable/ripple_primary_corner_4"
             android:gravity="center"
             android:onClickListener="@{() -> vm.gotoAddGifticon()}"
             android:padding="12dp"
             android:text="@string/add_gifticon_register"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Button"
             android:textColor="?attr/colorOnPrimary"
             android:textStyle="bold"
             app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
resolved: #266 

### 읽기 전 주의사항
- lint를 120으로 할 경우 gitHub Actions에서 잡는 lint가 너무 많아서 100으로 변경
- 그렇기에 현재 작업 내용에서 lint로 인한 변경 사항이 존재함

## 작업 내용

- 기프티콘을 전부 갖고 와서 transfrom 해서 각각의 객체로 사용하던 것에서 로컬로 변경
- 예시로 브랜드명을 갖고 온다고 했을 때
  - 기존) 기프티콘 전부 갖고와서 brand명을 기준으로 map
  - 개선) brand 명을 기준으로 room에서 갖고 오기
- 브랜드명, 홈화면에서 사용되는 기프티콘(7개 보여주는 객체)를 우선 변경

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정