### PR TITLE
만료된 기프티콘 기본으로 표시 및 UI 변경 + 목록 애니메이션 추가

### DIFF
--- a/data/src/main/java/com/lighthouse/database/dao/GifticonDao.kt
+++ b/data/src/main/java/com/lighthouse/database/dao/GifticonDao.kt
@@ -237,7 +237,9 @@ interface GifticonDao {
      */
     @Query(
         "SELECT * FROM $GIFTICON_TABLE " +
-            "WHERE user_id = :userId AND expire_at >= :time AND is_used = 0 LIMIT :count",
+            "WHERE user_id = :userId AND expire_at >= :time AND is_used = 0 " +
+            "ORDER BY expire_at " +
+            "LIMIT :count",
     )
     fun getSomeGifticons(userId: String, time: Date, count: Int): Flow<List<GifticonEntity>>
 }

--- a/data/src/main/java/com/lighthouse/database/dao/GifticonDao.kt
+++ b/data/src/main/java/com/lighthouse/database/dao/GifticonDao.kt
@@ -27,7 +27,11 @@ interface GifticonDao {
     @Query("SELECT * FROM $GIFTICON_TABLE WHERE id = :id")
     fun getGifticon(id: String): Flow<GifticonEntity>
 
-    @Query("SELECT * FROM $GIFTICON_TABLE WHERE user_id = :userId AND is_used = 0 ORDER BY created_at DESC")
+    @Query(
+        "SELECT * FROM $GIFTICON_TABLE " +
+            "WHERE user_id = :userId AND is_used = 0 " +
+            "ORDER BY (CASE WHEN expire_at < STRFTIME('%s', DATE('now')) * 1000 THEN 1 ELSE 0 END), created_at DESC",
+    )
     fun getAllGifticons(userId: String): Flow<List<GifticonEntity>>
 
     @Query("SELECT * FROM $GIFTICON_TABLE WHERE user_id = :userId AND is_used = 1 ORDER BY created_at DESC")
@@ -36,16 +40,28 @@ interface GifticonDao {
     @Query("SELECT * FROM $GIFTICON_TABLE WHERE user_id = :userId AND expire_at >= :time AND is_used = 0 ORDER BY expire_at")
     fun getAllUsableGifticons(userId: String, time: Date): Flow<List<GifticonEntity>>
 
-    @Query("SELECT * FROM $GIFTICON_TABLE WHERE user_id = :userId AND is_used = 0 ORDER BY expire_at")
+    @Query(
+        "SELECT * FROM $GIFTICON_TABLE " +
+            "WHERE user_id = :userId AND is_used = 0 " +
+            "ORDER BY (CASE WHEN expire_at < STRFTIME('%s', DATE('now')) * 1000 THEN 1 ELSE 0 END), expire_at",
+    )
     fun getAllGifticonsSortByDeadline(userId: String): Flow<List<GifticonEntity>>
 
-    @Query("SELECT * FROM $GIFTICON_TABLE WHERE user_id = :userId AND is_used = 0 AND UPPER(brand) IN(:filters) ORDER BY created_at DESC")
+    @Query(
+        "SELECT * FROM $GIFTICON_TABLE " +
+            "WHERE user_id = :userId AND is_used = 0 AND UPPER(brand) IN(:filters) " +
+            "ORDER BY (CASE WHEN expire_at < STRFTIME('%s', DATE('now')) * 1000 THEN 1 ELSE 0 END), created_at DESC",
+    )
     fun getFilteredGifticons(userId: String, filters: Set<String>): Flow<List<GifticonEntity>>
 
-    @Query("SELECT * FROM $GIFTICON_TABLE WHERE user_id = :userId AND is_used = 0 AND UPPER(brand) IN(:filters) ORDER BY expire_at")
+    @Query(
+        "SELECT * FROM $GIFTICON_TABLE " +
+            "WHERE user_id = :userId AND is_used = 0 AND UPPER(brand) IN(:filters) " +
+            "ORDER BY (CASE WHEN expire_at < STRFTIME('%s', DATE('now')) * 1000 THEN 1 ELSE 0 END), expire_at",
+    )
     fun getFilteredGifticonsSortByDeadline(
         userId: String,
-        filters: Set<String>
+        filters: Set<String>,
     ): Flow<List<GifticonEntity>>
 
     @Query(
@@ -53,7 +69,7 @@ interface GifticonDao {
             "INNER JOIN $GIFTICON_CROP_TABLE " +
             "ON $GIFTICON_TABLE.id = $GIFTICON_CROP_TABLE.gifticon_id " +
             "WHERE id = :id AND user_id = :userId " +
-            "LIMIT 1"
+            "LIMIT 1",
     )
     suspend fun getGifticonWithCrop(userId: String, id: String): GifticonWithCrop?
 
@@ -61,7 +77,7 @@ interface GifticonDao {
         "SELECT brand AS name, COUNT(*) AS count " +
             "FROM $GIFTICON_TABLE " +
             "WHERE user_id = :userId " +
-            "GROUP BY brand ORDER BY count DESC"
+            "GROUP BY brand ORDER BY count DESC",
     )
     fun getAllBrands(userId: String): Flow<List<Brand>>
 
@@ -128,7 +144,7 @@ interface GifticonDao {
             "is_cash_card = :isCashCard, " +
             "balance = :balance, " +
             "memo = :memo " +
-            "WHERE id = :id"
+            "WHERE id = :id",
     )
     suspend fun updateGifticon(
         id: String,
@@ -139,7 +155,7 @@ interface GifticonDao {
         barcode: String,
         isCashCard: Boolean,
         balance: Int,
-        memo: String
+        memo: String,
     )
 
     @Query("UPDATE $GIFTICON_CROP_TABLE SET cropped_rect = :croppedRect WHERE gifticon_id = :id")
@@ -157,7 +173,7 @@ interface GifticonDao {
                 barcode,
                 isCashCard,
                 balance,
-                memo
+                memo,
             )
             updateGifticonCrop(id, croppedRect)
         }
@@ -197,7 +213,7 @@ interface GifticonDao {
 
     @Query(
         "SELECT EXISTS (SELECT * FROM $GIFTICON_TABLE " +
-            "WHERE expire_at >= :time AND is_used = 0 AND user_id = :userId)"
+            "WHERE expire_at >= :time AND is_used = 0 AND user_id = :userId)",
     )
     fun hasUsableGifticon(userId: String, time: Date): Flow<Boolean>
 
@@ -212,7 +228,7 @@ interface GifticonDao {
      */
     @Query(
         "SELECT DISTINCT brand FROM $GIFTICON_TABLE " +
-            "WHERE user_id = :userId AND expire_at >= :time AND is_used = 0"
+            "WHERE user_id = :userId AND expire_at >= :time AND is_used = 0",
     )
     fun getGifticonBrands(userId: String, time: Date): Flow<List<String>>
 
@@ -221,7 +237,7 @@ interface GifticonDao {
      */
     @Query(
         "SELECT * FROM $GIFTICON_TABLE " +
-            "WHERE user_id = :userId AND expire_at >= :time AND is_used = 0 LIMIT :count"
+            "WHERE user_id = :userId AND expire_at >= :time AND is_used = 0 LIMIT :count",
     )
     fun getSomeGifticons(userId: String, time: Date, count: Int): Flow<List<GifticonEntity>>
 }

--- a/data/src/main/java/com/lighthouse/datasource/gifticon/GifticonLocalDataSource.kt
+++ b/data/src/main/java/com/lighthouse/datasource/gifticon/GifticonLocalDataSource.kt
@@ -16,10 +16,10 @@ interface GifticonLocalDataSource {
     fun getFilteredGifticons(
         userId: String,
         filter: Set<String>,
-        sortBy: SortBy = SortBy.DEADLINE
+        sortBy: SortBy = SortBy.DEADLINE,
     ): Flow<List<Gifticon>>
 
-    fun getAllBrands(userId: String, filterExpired: Boolean): Flow<List<Brand>>
+    fun getAllBrands(userId: String): Flow<List<Brand>>
     suspend fun getGifticonCrop(userId: String, gifticonId: String): GifticonWithCrop?
     suspend fun insertGifticons(gifticons: List<GifticonWithCrop>)
     suspend fun updateGifticon(gifticonWithCrop: GifticonWithCrop)

--- a/data/src/main/java/com/lighthouse/datasource/gifticon/GifticonLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/lighthouse/datasource/gifticon/GifticonLocalDataSourceImpl.kt
@@ -9,7 +9,6 @@ import com.lighthouse.domain.model.Brand
 import com.lighthouse.domain.model.Gifticon
 import com.lighthouse.domain.model.SortBy
 import com.lighthouse.domain.model.UsageHistory
-import com.lighthouse.domain.util.isExpired
 import com.lighthouse.domain.util.today
 import com.lighthouse.mapper.toDomain
 import kotlinx.coroutines.flow.Flow
@@ -17,7 +16,7 @@ import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class GifticonLocalDataSourceImpl @Inject constructor(
-    private val gifticonDao: GifticonDao
+    private val gifticonDao: GifticonDao,
 ) : GifticonLocalDataSource {
 
     override fun getGifticon(id: String): Flow<Gifticon> {
@@ -45,7 +44,7 @@ class GifticonLocalDataSourceImpl @Inject constructor(
     override fun getFilteredGifticons(
         userId: String,
         filter: Set<String>,
-        sortBy: SortBy
+        sortBy: SortBy,
     ): Flow<List<Gifticon>> {
         val upperFilter = filter.map { it.uppercase() }.toSet()
         val gifticons = when (sortBy) {
@@ -57,15 +56,9 @@ class GifticonLocalDataSourceImpl @Inject constructor(
         }
     }
 
-    override fun getAllBrands(userId: String, filterExpired: Boolean): Flow<List<Brand>> {
+    override fun getAllBrands(userId: String): Flow<List<Brand>> {
         return gifticonDao.getAllGifticons(userId).map {
-            if (filterExpired) {
-                it.filterNot { entity ->
-                    entity.expireAt.isExpired()
-                }
-            } else {
-                it
-            }.groupBy { entity ->
+            it.groupBy { entity ->
                 entity.brand.uppercase()
             }.map { entry ->
                 Brand(entry.key.uppercase(), entry.value.size)
@@ -92,11 +85,11 @@ class GifticonLocalDataSourceImpl @Inject constructor(
     override suspend fun useCashCardGifticon(
         gifticonId: String,
         amount: Int,
-        usageHistory: UsageHistory
+        usageHistory: UsageHistory,
     ) {
         gifticonDao.useCashCardGifticonTransaction(
             amount,
-            usageHistory.toUsageHistoryEntity(gifticonId)
+            usageHistory.toUsageHistoryEntity(gifticonId),
         )
     }
 

--- a/data/src/main/java/com/lighthouse/datasource/gifticon/GifticonLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/lighthouse/datasource/gifticon/GifticonLocalDataSourceImpl.kt
@@ -9,6 +9,7 @@ import com.lighthouse.domain.model.Brand
 import com.lighthouse.domain.model.Gifticon
 import com.lighthouse.domain.model.SortBy
 import com.lighthouse.domain.model.UsageHistory
+import com.lighthouse.domain.util.isExpired
 import com.lighthouse.domain.util.today
 import com.lighthouse.mapper.toDomain
 import kotlinx.coroutines.flow.Flow
@@ -58,11 +59,12 @@ class GifticonLocalDataSourceImpl @Inject constructor(
 
     override fun getAllBrands(userId: String): Flow<List<Brand>> {
         return gifticonDao.getAllGifticons(userId).map {
-            it.groupBy { entity ->
-                entity.brand.uppercase()
-            }.map { entry ->
-                Brand(entry.key.uppercase(), entry.value.size)
-            }
+            it.filterNot { gifticon -> gifticon.expireAt.isExpired() }
+                .groupBy { entity ->
+                    entity.brand.uppercase()
+                }.map { entry ->
+                    Brand(entry.key.uppercase(), entry.value.size)
+                }
         }
     }
 

--- a/data/src/main/java/com/lighthouse/repository/GifticonRepositoryImpl.kt
+++ b/data/src/main/java/com/lighthouse/repository/GifticonRepositoryImpl.kt
@@ -23,7 +23,7 @@ import javax.inject.Inject
 
 class GifticonRepositoryImpl @Inject constructor(
     private val gifticonLocalDataSource: GifticonLocalDataSource,
-    private val gifticonImageSource: GifticonImageSource
+    private val gifticonImageSource: GifticonImageSource,
 ) : GifticonRepository {
 
     override fun getGifticon(id: String): Flow<DbResult<Gifticon>> = flow {
@@ -57,7 +57,7 @@ class GifticonRepositoryImpl @Inject constructor(
     override fun getFilteredGifticons(
         userId: String,
         filter: Set<String>,
-        sortBy: SortBy
+        sortBy: SortBy,
     ): Flow<DbResult<List<Gifticon>>> = flow {
         emit(DbResult.Loading)
         gifticonLocalDataSource.getFilteredGifticons(userId, filter, sortBy).collect {
@@ -67,10 +67,10 @@ class GifticonRepositoryImpl @Inject constructor(
         emit(DbResult.Failure(e))
     }
 
-    override fun getAllBrands(userId: String, filterExpired: Boolean): Flow<DbResult<List<Brand>>> =
+    override fun getAllBrands(userId: String): Flow<DbResult<List<Brand>>> =
         flow {
             emit(DbResult.Loading)
-            gifticonLocalDataSource.getAllBrands(userId, filterExpired).collect {
+            gifticonLocalDataSource.getAllBrands(userId).collect {
                 emit(DbResult.Success(it))
             }
         }.catch { e ->
@@ -87,7 +87,7 @@ class GifticonRepositoryImpl @Inject constructor(
             croppedUri = gifticonImageSource.updateImage(
                 gifticonForUpdate.id,
                 Uri.parse(gifticonForUpdate.oldCroppedUri),
-                Uri.parse(gifticonForUpdate.croppedUri)
+                Uri.parse(gifticonForUpdate.croppedUri),
             )
         }
         gifticonLocalDataSource.updateGifticon(gifticonForUpdate.toEntity(croppedUri))
@@ -95,7 +95,7 @@ class GifticonRepositoryImpl @Inject constructor(
 
     override suspend fun saveGifticons(
         userId: String,
-        gifticonForAdditions: List<GifticonForAddition>
+        gifticonForAdditions: List<GifticonForAddition>,
     ) {
         val newGifticons = gifticonForAdditions.map { gifticonForAddition ->
             val id = UUID.generate()
@@ -104,7 +104,7 @@ class GifticonRepositoryImpl @Inject constructor(
                 result = gifticonImageSource.saveImage(
                     id,
                     Uri.parse(gifticonForAddition.originUri),
-                    Uri.parse(gifticonForAddition.tempCroppedUri)
+                    Uri.parse(gifticonForAddition.tempCroppedUri),
                 )
             }
             gifticonForAddition.toEntity(id, userId, result)
@@ -136,7 +136,7 @@ class GifticonRepositoryImpl @Inject constructor(
     override suspend fun useCashCardGifticon(
         gifticonId: String,
         amount: Int,
-        usageHistory: UsageHistory
+        usageHistory: UsageHistory,
     ) {
         gifticonLocalDataSource.useCashCardGifticon(gifticonId, amount, usageHistory)
     }

--- a/domain/src/main/java/com/lighthouse/domain/repository/GifticonRepository.kt
+++ b/domain/src/main/java/com/lighthouse/domain/repository/GifticonRepository.kt
@@ -17,10 +17,10 @@ interface GifticonRepository {
     fun getFilteredGifticons(
         userId: String,
         filter: Set<String>,
-        sortBy: SortBy = SortBy.DEADLINE
+        sortBy: SortBy = SortBy.DEADLINE,
     ): Flow<DbResult<List<Gifticon>>>
 
-    fun getAllBrands(userId: String, filterExpired: Boolean): Flow<DbResult<List<Brand>>>
+    fun getAllBrands(userId: String): Flow<DbResult<List<Brand>>>
     suspend fun saveGifticons(userId: String, gifticonForAdditions: List<GifticonForAddition>)
     suspend fun getGifticonCrop(userId: String, id: String): GifticonForUpdate?
     suspend fun updateGifticon(gifticonForUpdate: GifticonForUpdate)

--- a/domain/src/main/java/com/lighthouse/domain/usecase/GetAllBrandsUseCase.kt
+++ b/domain/src/main/java/com/lighthouse/domain/usecase/GetAllBrandsUseCase.kt
@@ -10,12 +10,12 @@ import javax.inject.Inject
 
 class GetAllBrandsUseCase @Inject constructor(
     private val gifticonRepository: GifticonRepository,
-    authRepository: AuthRepository
+    authRepository: AuthRepository,
 ) {
     val userId = authRepository.getCurrentUserId()
 
-    operator fun invoke(filterExpired: Boolean = false): Flow<DbResult<List<Brand>>> {
-        return gifticonRepository.getAllBrands(userId, filterExpired).transform {
+    operator fun invoke(): Flow<DbResult<List<Brand>>> {
+        return gifticonRepository.getAllBrands(userId).transform {
             if (it is DbResult.Success) {
                 emit(DbResult.Success(it.data.sortedByDescending { brand -> brand.count }))
             } else {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,7 +70,6 @@ androidX-work-testing = { module = "androidx.work:work-testing", version.ref = "
 ## Accompanist
 accompanist-appcompat-theme = { module = "com.google.accompanist:accompanist-appcompat-theme", version.ref = "accompanist" }
 accompanist-flowlayout = { module = "com.google.accompanist:accompanist-flowlayout", version.ref = "accompanist" }
-accompanist-placeholder-material = { module = "com.google.accompanist:accompanist-placeholder-material", version.ref = "accompanist" }
 ## Dagger
 dagger-hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "dagger" }
 dagger-hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "dagger" }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -38,7 +38,6 @@ dependencies {
 
     implementation(libs.accompanist.appcompat.theme)
     implementation(libs.accompanist.flowlayout)
-    implementation(libs.accompanist.placeholder.material)
 
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.auth.ktx)

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/GifticonListViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/GifticonListViewModel.kt
@@ -9,17 +9,16 @@ import com.lighthouse.domain.usecase.GetAllBrandsUseCase
 import com.lighthouse.domain.usecase.GetFilteredGifticonsUseCase
 import com.lighthouse.domain.usecase.RemoveGifticonUseCase
 import com.lighthouse.domain.usecase.UseGifticonUseCase
-import com.lighthouse.domain.util.isExpired
 import com.lighthouse.presentation.mapper.toDomain
 import com.lighthouse.presentation.mapper.toPresentation
 import com.lighthouse.presentation.model.GifticonSortBy
 import com.lighthouse.presentation.model.GifticonUIModel
-import com.lighthouse.presentation.util.flow.combine
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
@@ -33,15 +32,15 @@ class GifticonListViewModel @Inject constructor(
     getAllBrandsUseCase: GetAllBrandsUseCase,
     private val getFilteredGifticonsUseCase: GetFilteredGifticonsUseCase,
     private val useGifticonUseCase: UseGifticonUseCase,
-    private val removeGifticonUseCase: RemoveGifticonUseCase
+    private val removeGifticonUseCase: RemoveGifticonUseCase,
 ) : ViewModel() {
 
     private val filter = MutableStateFlow(setOf<String>())
     private val sortBy = MutableStateFlow(GifticonSortBy.DEADLINE)
     private val gifticons = MutableStateFlow<DbResult<List<Gifticon>>>(DbResult.Loading)
-    private val brands = MutableStateFlow<DbResult<List<Brand>>>(DbResult.Loading)
+    private val brands =
+        getAllBrandsUseCase().stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DbResult.Loading)
     private val entireBrandsDialogShown = MutableStateFlow(false)
-    private val showExpiredGifticon = MutableStateFlow(false)
 
     init {
         viewModelScope.launch {
@@ -58,24 +57,15 @@ class GifticonListViewModel @Inject constructor(
                 gifticons.value = dbResult
             }
         }
-        viewModelScope.launch {
-            showExpiredGifticon.flatMapLatest { showExpired ->
-                getAllBrandsUseCase(showExpired.not()).distinctUntilChanged()
-            }.debounce(50).collect { dbResult ->
-                filter.value = emptySet() // 만료된 기프티콘 표시 옵션이 변경되면 필터 초기화
-                brands.value = dbResult
-            }
-        }
     }
 
     val state = combine(
         sortBy,
         gifticons,
-        showExpiredGifticon,
         brands,
         entireBrandsDialogShown,
-        filter
-    ) { sortBy, gifticonResult, showExpired, brandResult, entireBrandsDialogShown, filter ->
+        filter,
+    ) { sortBy, gifticonResult, brandResult, entireBrandsDialogShown, filter ->
         when (gifticonResult) {
             is DbResult.Success -> {
                 val brands = when (brandResult) {
@@ -86,18 +76,14 @@ class GifticonListViewModel @Inject constructor(
                 }
                 GifticonListViewState(
                     sortBy = sortBy,
-                    gifticons = if (showExpired) {
-                        gifticonResult.data.map { it.toPresentation() }
-                    } else {
-                        gifticonResult.data.filterNot { it.expireAt.isExpired() }.map { it.toPresentation() }
-                    },
-                    showExpiredGifticon = showExpired,
+                    gifticons = gifticonResult.data.map { it.toPresentation() },
                     brands = brands,
                     entireBrandsDialogShown = entireBrandsDialogShown,
                     selectedFilter = filter,
-                    loading = false
+                    loading = false,
                 )
             }
+
             is DbResult.Loading -> {
                 val gifticons = gifticons.value.let { result ->
                     if (result is DbResult.Success) result.data.map { it.toPresentation() } else emptyList()
@@ -108,9 +94,10 @@ class GifticonListViewModel @Inject constructor(
                     brands = emptyList(),
                     entireBrandsDialogShown = entireBrandsDialogShown,
                     selectedFilter = filter,
-                    loading = true
+                    loading = true,
                 )
             }
+
             else -> {
                 GifticonListViewState()
             }
@@ -131,10 +118,6 @@ class GifticonListViewModel @Inject constructor(
         } else {
             filter.value.plus(brand.name)
         }
-    }
-
-    fun filterUsedGifticon(show: Boolean = true) {
-        showExpiredGifticon.value = show
     }
 
     fun clearFilter() {

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/GifticonListViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/GifticonListViewModel.kt
@@ -120,6 +120,10 @@ class GifticonListViewModel @Inject constructor(
         }
     }
 
+    fun updateFilterSelection(selectedBrands: Set<String>) {
+        filter.value = selectedBrands
+    }
+
     fun clearFilter() {
         filter.value = emptySet()
     }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/GifticonListViewState.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/GifticonListViewState.kt
@@ -7,10 +7,9 @@ import com.lighthouse.presentation.model.GifticonUIModel
 data class GifticonListViewState(
     val sortBy: GifticonSortBy = GifticonSortBy.DEADLINE,
     val gifticons: List<GifticonUIModel> = emptyList(),
-    val showExpiredGifticon: Boolean = false,
     val loading: Boolean = false,
     val brands: List<Brand> = emptyList(),
     val selectedFilter: Set<String> = emptySet(),
     val entireBrandsDialogShown: Boolean = false,
-    val errorMessage: String? = null
+    val errorMessage: String? = null,
 )

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/BrandChip.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/BrandChip.kt
@@ -114,7 +114,7 @@ fun BrandChipList(
             }
         }
         val sortedBrands = brands.sortedByDescending { selectedFilters.contains(it.name) }
-        items(sortedBrands) { brand ->
+        items(sortedBrands, key = { brand -> brand.name }) { brand ->
             BrandChip(
                 brand = brand,
                 selected = selectedFilters.contains(brand.name),

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/BrandChip.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/BrandChip.kt
@@ -8,10 +8,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyRow
@@ -22,7 +20,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ChipDefaults
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.FilterChip
-import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
@@ -34,7 +31,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.stringResource
@@ -46,9 +42,6 @@ import androidx.compose.ui.window.DialogProperties
 import com.google.accompanist.flowlayout.FlowMainAxisAlignment
 import com.google.accompanist.flowlayout.FlowRow
 import com.google.accompanist.flowlayout.SizeMode
-import com.google.accompanist.placeholder.PlaceholderHighlight
-import com.google.accompanist.placeholder.material.placeholder
-import com.google.accompanist.placeholder.material.shimmer
 import com.lighthouse.domain.model.Brand
 import com.lighthouse.presentation.R
 
@@ -219,60 +212,6 @@ fun BrandChip(
     }
 }
 
-@Composable
-fun BrandChipLoadingScreen(modifier: Modifier = Modifier) {
-    Row(
-        modifier = modifier,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        BrandChipLoadingList(
-            Modifier
-                .weight(1f)
-                .padding(end = 16.dp),
-            5,
-        )
-        Icon(
-            modifier = Modifier.placeholder(
-                visible = true,
-                highlight = PlaceholderHighlight.shimmer(),
-            ),
-            imageVector = Icons.Outlined.Tune,
-            contentDescription = null,
-        )
-    }
-}
-
-@Composable
-fun BrandChipLoadingList(modifier: Modifier = Modifier, count: Int = 3) {
-    LazyRow(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
-        items(count) {
-            BrandChipLoading()
-        }
-    }
-}
-
-@Composable
-fun BrandChipLoading(modifier: Modifier = Modifier) {
-    Spacer(
-        modifier = modifier
-            .size(60.dp, 30.dp)
-            .clip(RoundedCornerShape(16.dp))
-            .placeholder(
-                visible = true,
-                highlight = PlaceholderHighlight.shimmer(),
-            ),
-    )
-}
-
-@Preview(widthDp = 320, heightDp = 700)
-@Composable
-fun BrandChipLoadingPreview() {
-    BrandChipLoading()
-}
-
 @Preview(widthDp = 500, heightDp = 500)
 @Composable
 fun AllBrandChipsDialogPreview() {
@@ -285,10 +224,4 @@ fun AllBrandChipsDialogPreview() {
             Brand("파리바게트", 8),
         ),
     )
-}
-
-@Preview
-@Composable
-fun BrandChipLoadingListPreview() {
-    BrandChipLoadingList()
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/BrandChip.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/BrandChip.kt
@@ -1,5 +1,6 @@
 package com.lighthouse.presentation.ui.gifticonlist.component
 
+import android.util.Log
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -8,6 +9,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
@@ -17,6 +19,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Button
 import androidx.compose.material.ChipDefaults
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.FilterChip
@@ -24,9 +27,12 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -126,10 +132,14 @@ fun AllBrandChipsDialog(
     modifier: Modifier = Modifier,
     brands: List<Brand> = emptyList(),
     selectedFilters: Set<String> = emptySet(),
-    onClickChip: (Brand) -> Unit = {},
+    onApply: (Set<String>) -> Unit = {},
     onDismiss: () -> Unit = {},
 ) {
     val interactionSource = remember { MutableInteractionSource() }
+
+    val newSelectedFilters = remember { mutableStateOf(selectedFilters) }
+    Log.d("로그", "_AllBrandChipsDialog: newFilter: ${newSelectedFilters.value}")
+
     Dialog(
         onDismissRequest = { onDismiss() },
         properties = DialogProperties(
@@ -152,11 +162,11 @@ fun AllBrandChipsDialog(
                 shape = RoundedCornerShape(12.dp),
                 color = MaterialTheme.colors.background,
             ) {
-                Column {
+                Column(modifier = Modifier.padding(16.dp)) {
                     val scrollState = rememberScrollState()
+                    // BrandChips
                     FlowRow(
                         modifier = Modifier
-                            .padding(16.dp)
                             .verticalScroll(scrollState),
                         mainAxisAlignment = FlowMainAxisAlignment.Start,
                         mainAxisSpacing = 8.dp,
@@ -165,10 +175,34 @@ fun AllBrandChipsDialog(
                         brands.forEach {
                             BrandChip(
                                 brand = it,
-                                selected = selectedFilters.contains(it.name),
+                                selected = newSelectedFilters.value.contains(it.name),
                             ) { selected ->
-                                onClickChip(selected)
+                                if (newSelectedFilters.value.contains(selected.name)) {
+                                    newSelectedFilters.value = newSelectedFilters.value.toMutableSet().apply {
+                                        remove(selected.name)
+                                    }
+                                } else {
+                                    newSelectedFilters.value = newSelectedFilters.value.toMutableSet().apply {
+                                        add(selected.name)
+                                    }
+                                }
                             }
+                        }
+                    }
+                    // Buttons
+                    Row(modifier = Modifier.padding(top = 24.dp)) {
+                        TextButton(
+                            onClick = { onDismiss() },
+                            shape = RoundedCornerShape(12.dp),
+                        ) {
+                            Text(text = stringResource(id = R.string.all_cancel))
+                        }
+                        Spacer(modifier = Modifier.weight(1f))
+                        Button(
+                            onClick = { onApply(newSelectedFilters.value.toSet()) },
+                            shape = RoundedCornerShape(12.dp),
+                        ) {
+                            Text(text = stringResource(id = R.string.all_apply), color = MaterialTheme.colors.surface)
                         }
                     }
                 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/BrandChip.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/BrandChip.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -49,7 +50,6 @@ import com.google.accompanist.placeholder.material.placeholder
 import com.google.accompanist.placeholder.material.shimmer
 import com.lighthouse.domain.model.Brand
 import com.lighthouse.presentation.R
-import com.lighthouse.presentation.ui.common.compose.TextCheckbox
 
 @Composable
 fun BrandChipListScreen(
@@ -58,10 +58,10 @@ fun BrandChipListScreen(
     filters: Set<String>,
     onClickEntireBrandDialog: () -> Unit = {},
     onClickTotalChip: () -> Unit = {},
-    onClickChip: (Brand) -> Unit = {}
+    onClickChip: (Brand) -> Unit = {},
 ) {
     Row(
-        modifier = modifier
+        modifier = modifier,
     ) {
         BrandChipList(
             modifier = Modifier.weight(1f),
@@ -72,18 +72,18 @@ fun BrandChipListScreen(
             },
             onClickChip = {
                 onClickChip(it)
-            }
+            },
         )
         IconButton(
             modifier = Modifier,
             onClick = {
                 onClickEntireBrandDialog()
-            }
+            },
         ) {
             Image(
                 imageVector = Icons.Outlined.Tune,
                 colorFilter = ColorFilter.tint(MaterialTheme.colors.onSurface),
-                contentDescription = stringResource(R.string.gifticon_list_show_all_brand_chips_button)
+                contentDescription = stringResource(R.string.gifticon_list_show_all_brand_chips_button),
             )
         }
     }
@@ -95,20 +95,20 @@ fun BrandChipList(
     brands: List<Brand> = emptyList(),
     selectedFilters: Set<String> = emptySet(),
     onClickTotalChip: () -> Unit = {},
-    onClickChip: (Brand) -> Unit = {}
+    onClickChip: (Brand) -> Unit = {},
 ) {
     LazyRow(
         modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(4.dp)
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         item { // "전체" 칩
             val entireChipBrand = Brand(
                 name = stringResource(id = R.string.main_filter_all),
-                count = brands.sumOf { it.count }
+                count = brands.sumOf { it.count },
             )
             BrandChip(
                 brand = entireChipBrand,
-                selected = selectedFilters.isEmpty()
+                selected = selectedFilters.isEmpty(),
             ) {
                 onClickTotalChip()
             }
@@ -116,7 +116,7 @@ fun BrandChipList(
         items(brands) { brand ->
             BrandChip(
                 brand = brand,
-                selected = selectedFilters.contains(brand.name)
+                selected = selectedFilters.contains(brand.name),
             ) {
                 onClickChip(brand)
             }
@@ -129,18 +129,16 @@ fun BrandChipList(
 fun AllBrandChipsDialog(
     modifier: Modifier = Modifier,
     brands: List<Brand> = emptyList(),
-    showExpiredGifticon: Boolean = false,
     selectedFilters: Set<String> = emptySet(),
-    onCheckFilterExpired: (Boolean) -> Unit = {},
     onClickChip: (Brand) -> Unit = {},
-    onDismiss: () -> Unit = {}
+    onDismiss: () -> Unit = {},
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     Dialog(
         onDismissRequest = { onDismiss() },
         properties = DialogProperties(
-            usePlatformDefaultWidth = false // 다이얼로그 너비 제한 제거
-        )
+            usePlatformDefaultWidth = false, // 다이얼로그 너비 제한 제거
+        ),
     ) {
         Box(
             contentAlignment = Alignment.Center,
@@ -148,24 +146,17 @@ fun AllBrandChipsDialog(
                 .fillMaxSize()
                 .clickable(
                     interactionSource = interactionSource, // Ripple 효과 제거
-                    indication = null
+                    indication = null,
                 ) {
                     onDismiss()
-                }
+                },
         ) {
             Surface(
                 modifier = modifier,
                 shape = RoundedCornerShape(12.dp),
-                color = MaterialTheme.colors.background
+                color = MaterialTheme.colors.background,
             ) {
                 Column {
-                    TextCheckbox(
-                        checked = showExpiredGifticon,
-                        textStyle = MaterialTheme.typography.body2,
-                        text = stringResource(R.string.gifticon_list_brands_dialog_show_expired_gifticon_option)
-                    ) { checked ->
-                        onCheckFilterExpired(checked)
-                    }
                     val scrollState = rememberScrollState()
                     FlowRow(
                         modifier = Modifier
@@ -173,12 +164,12 @@ fun AllBrandChipsDialog(
                             .verticalScroll(scrollState),
                         mainAxisAlignment = FlowMainAxisAlignment.Start,
                         mainAxisSpacing = 8.dp,
-                        mainAxisSize = SizeMode.Expand
+                        mainAxisSize = SizeMode.Expand,
                     ) {
                         brands.forEach {
                             BrandChip(
                                 brand = it,
-                                selected = selectedFilters.contains(it.name)
+                                selected = selectedFilters.contains(it.name),
                             ) { selected ->
                                 onClickChip(selected)
                             }
@@ -196,7 +187,7 @@ fun BrandChip(
     brand: Brand,
     modifier: Modifier = Modifier,
     selected: Boolean = false,
-    onClick: (Brand) -> Unit = {}
+    onClick: (Brand) -> Unit = {},
 ) {
     FilterChip(
         selected = selected,
@@ -208,18 +199,18 @@ fun BrandChip(
             backgroundColor = MaterialTheme.colors.onSurface.copy(alpha = 0.1f),
             contentColor = MaterialTheme.colors.onSurface,
             selectedBackgroundColor = MaterialTheme.colors.primary,
-            selectedContentColor = Color.White
-        )
+            selectedContentColor = Color.White,
+        ),
     ) {
         Row(
             horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(text = brand.name, maxLines = 1, overflow = TextOverflow.Ellipsis)
             Text(
                 text = brand.count.toString(),
                 modifier = Modifier.padding(start = 4.dp),
-                color = MaterialTheme.colors.onSurface.copy(alpha = 0.5f)
+                color = MaterialTheme.colors.onSurface.copy(alpha = 0.5f),
             )
         }
     }
@@ -229,21 +220,21 @@ fun BrandChip(
 fun BrandChipLoadingScreen(modifier: Modifier = Modifier) {
     Row(
         modifier = modifier,
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         BrandChipLoadingList(
             Modifier
                 .weight(1f)
                 .padding(end = 16.dp),
-            5
+            5,
         )
         Icon(
             modifier = Modifier.placeholder(
                 visible = true,
-                highlight = PlaceholderHighlight.shimmer()
+                highlight = PlaceholderHighlight.shimmer(),
             ),
             imageVector = Icons.Outlined.Tune,
-            contentDescription = null
+            contentDescription = null,
         )
     }
 }
@@ -252,7 +243,7 @@ fun BrandChipLoadingScreen(modifier: Modifier = Modifier) {
 fun BrandChipLoadingList(modifier: Modifier = Modifier, count: Int = 3) {
     LazyRow(
         modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(4.dp)
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         items(count) {
             BrandChipLoading()
@@ -268,8 +259,8 @@ fun BrandChipLoading(modifier: Modifier = Modifier) {
             .clip(RoundedCornerShape(16.dp))
             .placeholder(
                 visible = true,
-                highlight = PlaceholderHighlight.shimmer()
-            )
+                highlight = PlaceholderHighlight.shimmer(),
+            ),
     )
 }
 
@@ -277,6 +268,20 @@ fun BrandChipLoading(modifier: Modifier = Modifier) {
 @Composable
 fun BrandChipLoadingPreview() {
     BrandChipLoading()
+}
+
+@Preview(widthDp = 500, heightDp = 500)
+@Composable
+fun AllBrandChipsDialogPreview() {
+    AllBrandChipsDialog(
+        modifier = Modifier.wrapContentSize(),
+        brands = listOf(
+            Brand("스타벅스", 10),
+            Brand("투썸플레이스", 2),
+            Brand("배스킨라빈스31", 5),
+            Brand("파리바게트", 8),
+        ),
+    )
 }
 
 @Preview

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/BrandChip.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/BrandChip.kt
@@ -1,5 +1,6 @@
 package com.lighthouse.presentation.ui.gifticonlist.component
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -89,6 +90,7 @@ fun BrandChipListScreen(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun BrandChipList(
     modifier: Modifier = Modifier,
@@ -108,6 +110,7 @@ fun BrandChipList(
             )
             BrandChip(
                 brand = entireChipBrand,
+                modifier = Modifier.animateItemPlacement(),
                 selected = selectedFilters.isEmpty(),
             ) {
                 onClickTotalChip()

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/BrandChip.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/BrandChip.kt
@@ -155,7 +155,10 @@ fun AllBrandChipsDialog(
                 },
         ) {
             Surface(
-                modifier = modifier,
+                modifier = modifier.clickable(
+                    interactionSource = interactionSource,
+                    indication = null,
+                ) { },
                 shape = RoundedCornerShape(12.dp),
                 color = MaterialTheme.colors.background,
             ) {

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/BrandChip.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/BrandChip.kt
@@ -1,6 +1,5 @@
 package com.lighthouse.presentation.ui.gifticonlist.component
 
-import android.util.Log
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -31,7 +30,6 @@ import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -115,7 +113,8 @@ fun BrandChipList(
                 onClickTotalChip()
             }
         }
-        items(brands) { brand ->
+        val sortedBrands = brands.sortedByDescending { selectedFilters.contains(it.name) }
+        items(sortedBrands) { brand ->
             BrandChip(
                 brand = brand,
                 selected = selectedFilters.contains(brand.name),
@@ -136,9 +135,7 @@ fun AllBrandChipsDialog(
     onDismiss: () -> Unit = {},
 ) {
     val interactionSource = remember { MutableInteractionSource() }
-
     val newSelectedFilters = remember { mutableStateOf(selectedFilters) }
-    Log.d("로그", "_AllBrandChipsDialog: newFilter: ${newSelectedFilters.value}")
 
     Dialog(
         onDismissRequest = { onDismiss() },

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonList.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonList.kt
@@ -2,6 +2,7 @@ package com.lighthouse.presentation.ui.gifticonlist.component
 
 import android.content.Intent
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -74,6 +75,7 @@ import com.skydoves.landscapist.glide.GlideImage
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun GifticonList(
     gifticons: List<GifticonUIModel>,
@@ -84,11 +86,13 @@ fun GifticonList(
     var showExpiredGifticons by rememberSaveable { mutableStateOf(true) }
 
     LazyColumn(
-        verticalArrangement = Arrangement.spacedBy(8.dp),
         modifier = modifier,
         contentPadding = PaddingValues(vertical = 36.dp),
     ) {
         itemsIndexed(items = gifticons, key = { _, item -> item.id }) { index, gifticon ->
+            var space = 8.dp
+
+            // 사용 기한 만료된 기프티콘 토글 열
             if (
                 index > 0 && gifticons.lastIndex >= index &&
                 gifticons[index - 1].expireAt.isExpired().not() && gifticon.expireAt.isExpired()
@@ -96,10 +100,19 @@ fun GifticonList(
                 ExpiredGifticonToggleColumn(showList = showExpiredGifticons) {
                     showExpiredGifticons = it
                 }
+                space = 0.dp
             }
+
+            // 기프티콘 목록
             if (gifticon.expireAt.isExpired().not() || showExpiredGifticons) {
+                if (index > 0) {
+                    Spacer(Modifier.height(space))
+                }
                 GifticonItem(
                     gifticon = gifticon,
+                    modifier = Modifier.animateItemPlacement(
+                        animationSpec = tween(600),
+                    ),
                     onUse = { onUse(it) },
                     onRemove = { onRemove(it) },
                 )
@@ -112,6 +125,7 @@ fun GifticonList(
 @Composable
 fun GifticonItem(
     gifticon: GifticonUIModel,
+    modifier: Modifier = Modifier,
     onUse: (GifticonUIModel) -> Unit = {},
     onRemove: (GifticonUIModel) -> Unit = {},
 ) {
@@ -122,7 +136,7 @@ fun GifticonItem(
     val scope = rememberCoroutineScope()
 
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .wrapContentHeight()
             .clip(RoundedCornerShape(cornerSize))
@@ -160,7 +174,7 @@ fun GifticonItem(
             onClick = {
                 onUse(gifticon)
                 scope.launch {
-                    swipeableState.animateTo(0, tween(600, 0))
+                    swipeableState.animateTo(0, tween(300, 0))
                 }
             },
             modifier = Modifier.align(Alignment.CenterEnd).padding(end = 20.dp).wrapContentWidth(),
@@ -264,11 +278,11 @@ fun GifticonItem(
 }
 
 @Composable
-fun ExpiredGifticonToggleColumn(showList: Boolean, onClick: (Boolean) -> Unit) {
+fun ExpiredGifticonToggleColumn(showList: Boolean, modifier: Modifier = Modifier, onClick: (Boolean) -> Unit) {
     val icon = if (showList) Icons.Default.KeyboardArrowDown else Icons.Default.KeyboardArrowRight
 
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .clickable { onClick(showList.not()) }
             .padding(vertical = 12.dp, horizontal = 8.dp),

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonList.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonList.kt
@@ -58,10 +58,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.google.accompanist.placeholder.PlaceholderHighlight
-import com.google.accompanist.placeholder.material.placeholder
-import com.google.accompanist.placeholder.material.shimmer
 import com.lighthouse.domain.util.isExpired
+import com.lighthouse.domain.util.today
 import com.lighthouse.presentation.R
 import com.lighthouse.presentation.extension.dpToPx
 import com.lighthouse.presentation.extension.toConcurrency
@@ -292,92 +290,6 @@ fun ExpiredGifticonToggleColumn(showList: Boolean, modifier: Modifier = Modifier
     }
 }
 
-@Composable
-fun GifticonLoadingList(count: Int = 5) {
-    LazyColumn(
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-        contentPadding = PaddingValues(vertical = 36.dp),
-    ) {
-        items(count) {
-            GifticonLoadingItem()
-        }
-    }
-}
-
-@Composable
-fun GifticonLoadingItem() {
-    val cornerSize = 8.dp
-
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(130.dp),
-        shape = MaterialTheme.shapes.medium.copy(CornerSize(cornerSize)),
-    ) {
-        Row {
-            Spacer(
-                modifier = Modifier.fillMaxHeight()
-                    .clip(RoundedCornerShape(topStart = cornerSize, bottomStart = cornerSize))
-                    .aspectRatio(1f)
-                    .align(Alignment.CenterVertically)
-                    .placeholder(
-                        visible = true,
-                        highlight = PlaceholderHighlight.shimmer(),
-                    ),
-            )
-            Box(
-                modifier = Modifier.fillMaxSize(),
-            ) {
-                Text(
-                    text = "D-00",
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(cornerSize))
-                        .placeholder(
-                            visible = true,
-                            highlight = PlaceholderHighlight.shimmer(),
-                        )
-                        .padding(horizontal = 16.dp, vertical = 8.dp)
-                        .align(Alignment.TopEnd),
-                )
-                Text(
-                    text = "~ 2022.00.00",
-                    modifier = Modifier
-                        .align(Alignment.BottomEnd)
-                        .padding(bottom = 16.dp, end = 16.dp)
-                        .placeholder(
-                            visible = true,
-                            highlight = PlaceholderHighlight.shimmer(),
-                        ),
-                )
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(horizontal = 16.dp, vertical = 8.dp),
-                    verticalArrangement = Arrangement.Center,
-                ) {
-                    Text(
-                        modifier = Modifier
-                            .padding(bottom = 4.dp)
-                            .placeholder(
-                                visible = true,
-                                highlight = PlaceholderHighlight.shimmer(),
-                            ),
-                        text = "브랜드 자리",
-                    )
-                    Text(
-                        modifier = Modifier
-                            .placeholder(
-                                visible = true,
-                                highlight = PlaceholderHighlight.shimmer(),
-                            ),
-                        text = "제목이 들어갈 자리입니다",
-                    )
-                }
-            }
-        }
-    }
-}
-
 @Preview
 @Composable
 fun ExpiredGifticonToggleColumnPreview() {
@@ -387,11 +299,19 @@ fun ExpiredGifticonToggleColumnPreview() {
 @Preview
 @Composable
 fun GifticonLoadingPreview() {
-    GifticonLoadingItem()
-}
-
-@Preview
-@Composable
-fun GifticonListLoadingPreview() {
-    GifticonLoadingList(3)
+    GifticonItem(
+        GifticonUIModel(
+            "",
+            true,
+            null,
+            "test 기프티콘",
+            "브랜드",
+            today,
+            "",
+            false,
+            0,
+            "",
+            false,
+        ),
+    )
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonList.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonList.kt
@@ -91,7 +91,7 @@ fun GifticonList(
         itemsIndexed(items = gifticons, key = { _, item -> item.id }) { index, gifticon ->
 
             // 사용 기한 만료된 기프티콘 토글 열
-            if (firstExpiredGifticon(gifticons, index)) {
+            if (isFirstExpiredGifticon(gifticons, index)) {
                 ExpiredGifticonToggleColumn(showList = showExpiredGifticons) {
                     showExpiredGifticons = it
                 }
@@ -118,7 +118,7 @@ fun GifticonList(
 }
 
 @Composable
-private fun firstExpiredGifticon(
+private fun isFirstExpiredGifticon(
     gifticons: List<GifticonUIModel>,
     index: Int,
 ) = index > 0 && gifticons.lastIndex >= index &&

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonList.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonList.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
@@ -292,7 +293,11 @@ fun ExpiredGifticonToggleColumn(showList: Boolean, modifier: Modifier = Modifier
             .clickable { onClick(showList.not()) }
             .padding(vertical = 12.dp, horizontal = 8.dp),
     ) {
-        Image(imageVector = icon, contentDescription = "show or hide expired gifticons icon")
+        Image(
+            imageVector = icon,
+            contentDescription = "show or hide expired gifticons icon",
+            colorFilter = ColorFilter.tint(color = MaterialTheme.colors.onSurface),
+        )
         Text(text = "사용 기한이 만료된 기프티콘", modifier = Modifier.weight(1f), textAlign = TextAlign.Center)
     }
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonList.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonList.kt
@@ -157,6 +157,7 @@ fun GifticonItem(
             )
             .background(if (swipeableState.offset.value < 0) colorResource(id = R.color.point_green_dark) else Color.Red),
     ) {
+        // 기프티콘 아이템 뒤 버튼들
         TextButton(
             onClick = {
                 onRemove(gifticon)
@@ -190,6 +191,7 @@ fun GifticonItem(
             )
         }
 
+        // 기프티콘 아이템
         Card(
             modifier = Modifier
                 .offset {
@@ -221,7 +223,7 @@ fun GifticonItem(
                         .align(Alignment.CenterVertically),
                 )
                 Box(
-                    modifier = Modifier.fillMaxSize().background(MaterialTheme.colors.surface),
+                    modifier = Modifier.fillMaxSize().background(MaterialTheme.colors.surface.copy(alpha = 0f)),
                 ) {
                     Text(
                         text = gifticon.expireAt.toDday(context),

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonList.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonList.kt
@@ -82,13 +82,13 @@ fun GifticonList(
     onRemove: (GifticonUIModel) -> Unit = {},
 ) {
     var showExpiredGifticons by rememberSaveable { mutableStateOf(true) }
+    var space = 8.dp
 
     LazyColumn(
         modifier = modifier,
         contentPadding = PaddingValues(vertical = 36.dp),
     ) {
         itemsIndexed(items = gifticons, key = { _, item -> item.id }) { index, gifticon ->
-            var space = 8.dp
 
             // 사용 기한 만료된 기프티콘 토글 열
             if (
@@ -114,6 +114,7 @@ fun GifticonList(
                     onUse = { onUse(it) },
                     onRemove = { onRemove(it) },
                 )
+                space = 8.dp
             }
         }
     }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonList.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonList.kt
@@ -91,10 +91,7 @@ fun GifticonList(
         itemsIndexed(items = gifticons, key = { _, item -> item.id }) { index, gifticon ->
 
             // 사용 기한 만료된 기프티콘 토글 열
-            if (
-                index > 0 && gifticons.lastIndex >= index &&
-                gifticons[index - 1].expireAt.isExpired().not() && gifticon.expireAt.isExpired()
-            ) {
+            if (firstExpiredGifticon(gifticons, index)) {
                 ExpiredGifticonToggleColumn(showList = showExpiredGifticons) {
                     showExpiredGifticons = it
                 }
@@ -119,6 +116,13 @@ fun GifticonList(
         }
     }
 }
+
+@Composable
+private fun firstExpiredGifticon(
+    gifticons: List<GifticonUIModel>,
+    index: Int,
+) = index > 0 && gifticons.lastIndex >= index &&
+    gifticons[index - 1].expireAt.isExpired().not() && gifticons[index].expireAt.isExpired()
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonListScreen.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonListScreen.kt
@@ -2,11 +2,13 @@ package com.lighthouse.presentation.ui.gifticonlist.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.AlertDialog
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
@@ -17,6 +19,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
@@ -43,39 +46,36 @@ fun GifticonListScreen(
             .padding(horizontal = 16.dp),
         color = Color.Transparent,
     ) {
+        if (viewState.loading) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+        }
         Column {
-            if (viewState.loading) {
-                BrandChipLoadingScreen(modifier = Modifier.padding(top = 24.dp))
-            } else {
-                BrandChipListScreen(
-                    modifier = Modifier.padding(top = 24.dp),
-                    brands = viewState.brands,
-                    filters = viewState.selectedFilter,
-                    onClickEntireBrandDialog = {
-                        viewModel.showEntireBrandsDialog()
-                    },
-                    onClickTotalChip = {
-                        viewModel.clearFilter()
-                    },
-                    onClickChip = {
-                        viewModel.toggleFilterSelection(it)
-                    },
-                )
-            }
-            if (viewState.loading) {
-                GifticonLoadingList()
-            } else {
-                GifticonList(
-                    gifticons = viewState.gifticons,
-                    Modifier.padding(top = 8.dp),
-                    onUse = {
-                        viewModel.completeUsage(it)
-                    },
-                    onRemove = {
-                        removeGifticonDialogState = it
-                    },
-                )
-            }
+            BrandChipListScreen(
+                modifier = Modifier.padding(top = 24.dp),
+                brands = viewState.brands,
+                filters = viewState.selectedFilter,
+                onClickEntireBrandDialog = {
+                    viewModel.showEntireBrandsDialog()
+                },
+                onClickTotalChip = {
+                    viewModel.clearFilter()
+                },
+                onClickChip = {
+                    viewModel.toggleFilterSelection(it)
+                },
+            )
+            GifticonList(
+                gifticons = viewState.gifticons,
+                Modifier.padding(top = 8.dp),
+                onUse = {
+                    viewModel.completeUsage(it)
+                },
+                onRemove = {
+                    removeGifticonDialogState = it
+                },
+            )
         }
         if (viewState.entireBrandsDialogShown) {
             AllBrandChipsDialog(

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonListScreen.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonListScreen.kt
@@ -31,7 +31,7 @@ import com.lighthouse.presentation.ui.gifticonlist.GifticonListViewModel
 @Composable
 fun GifticonListScreen(
     modifier: Modifier = Modifier,
-    viewModel: GifticonListViewModel = viewModel()
+    viewModel: GifticonListViewModel = viewModel(),
 ) {
     val viewState by viewModel.state.collectAsStateWithLifecycle()
     var removeGifticonDialogState by remember { mutableStateOf<GifticonUIModel?>(null) }
@@ -41,7 +41,7 @@ fun GifticonListScreen(
             .fillMaxSize()
             .background(Color.Black.copy(alpha = 0.05f))
             .padding(horizontal = 16.dp),
-        color = Color.Transparent
+        color = Color.Transparent,
     ) {
         Column {
             if (viewState.loading) {
@@ -59,7 +59,7 @@ fun GifticonListScreen(
                     },
                     onClickChip = {
                         viewModel.toggleFilterSelection(it)
-                    }
+                    },
                 )
             }
             if (viewState.loading) {
@@ -73,7 +73,7 @@ fun GifticonListScreen(
                     },
                     onRemove = {
                         removeGifticonDialogState = it
-                    }
+                    },
                 )
             }
         }
@@ -83,16 +83,12 @@ fun GifticonListScreen(
                 modifier = Modifier
                     .padding(16.dp),
                 selectedFilters = viewState.selectedFilter,
-                showExpiredGifticon = viewState.showExpiredGifticon,
-                onCheckFilterExpired = {
-                    viewModel.filterUsedGifticon(it)
-                },
                 onClickChip = {
                     viewModel.toggleFilterSelection(it)
                 },
                 onDismiss = {
                     viewModel.dismissEntireBrandsDialog()
-                }
+                },
             )
         }
     }
@@ -104,7 +100,7 @@ fun GifticonListScreen(
                     Image(
                         imageVector = Icons.Default.Warning,
                         contentDescription = null,
-                        colorFilter = ColorFilter.tint(Color.Red)
+                        colorFilter = ColorFilter.tint(Color.Red),
                     )
                     Text(stringResource(R.string.gifticon_list_remove_gifticon_dialog_title))
                 }
@@ -114,14 +110,14 @@ fun GifticonListScreen(
                 TextButton(
                     onClick = {
                         viewModel.removeGifticon(
-                            gifticon = removeGifticonDialogState ?: return@TextButton
+                            gifticon = removeGifticonDialogState ?: return@TextButton,
                         )
                         removeGifticonDialogState = null
-                    }
+                    },
                 ) {
                     Text(stringResource(R.string.gifticon_list_remove_gifticon_dialog_remove_button))
                 }
-            }
+            },
         )
     }
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonListScreen.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/gifticonlist/component/GifticonListScreen.kt
@@ -83,8 +83,9 @@ fun GifticonListScreen(
                 modifier = Modifier
                     .padding(16.dp),
                 selectedFilters = viewState.selectedFilter,
-                onClickChip = {
-                    viewModel.toggleFilterSelection(it)
+                onApply = {
+                    viewModel.updateFilterSelection(it)
+                    viewModel.dismissEntireBrandsDialog()
                 },
                 onDismiss = {
                     viewModel.dismissEntireBrandsDialog()

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="all_concurrency_format">#,###</string>
     <string name="all_balance_label">남은 금액:%s원</string>
     <string name="all_cancel">취소</string>
+    <string name="all_apply">적용</string>
     <string name="all_do_cancel">취소하기</string>
     <string name="all_d_day_more_than_year">D-365+</string>
     <string name="all_d_day_expired">만료</string>


### PR DESCRIPTION
resolved: #289 

## 작업 내용

- [x] 만료된 기프티콘을 기본으로 표시하도록 변경
- [x] 만료된 기프티콘은 기프티콘 목록 최하단에 위치하도록 변경
- [x] 정렬 기준이 생성 순이어도 만료된 기프티콘은 목록 최하단에 위치
- [x] 하나의 쿼리로 구분 (정렬 기준: 만료 여부(Boolean) →  정렬 기준(생성순/기한만료순)
- [x] 브랜드 선택 다이얼로그에 만료된 기프티콘 표시 옵션 제거
- [x] 만료된 기프티콘 파트를 접을 수 있는 UI 고려
- [x] 브랜드 목록에서 만료된 기프티콘은 제외하고 표시
- [x] Shimmer UI → CircularProgressIndicator 로 대체
- [x] 브랜드 선택 다이얼로그에서 적용 버튼을 눌러야 적용되도록 변경
- [x] 선택된 브랜드를 맨 앞에 배치

## 체크리스트

- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정

## 동작 화면

![list](https://user-images.githubusercontent.com/44221447/221006002-b57c1bd2-6e91-4604-811c-28d240ef2d35.gif)![brandchip](https://user-images.githubusercontent.com/44221447/221151746-f126d8c9-2376-4226-816e-515a8b37f366.gif)

## 버그

- ~~브랜드 목록에 엉뚱한 곳에 리플 효과가 나타나는 버그 (동작 화면 2에 포함되어 있음)~~ (해결)

