### PR TITLE
다이얼로그 동작 수정 및 사용한 기프티콘 화면 버그 수정

### DIFF
--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/CashCardGifticonInfoFragment.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/CashCardGifticonInfoFragment.kt
@@ -25,8 +25,5 @@ class CashCardGifticonInfoFragment : Fragment(R.layout.fragment_cash_card_giftic
         binding.vm = viewModel
         binding.geo = geography
         binding.lifecycleOwner = viewLifecycleOwner
-        binding.ctfBalance.addOnValueListener {
-            viewModel.editBalance(it)
-        }
     }
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailActivity.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailActivity.kt
@@ -70,15 +70,15 @@ class GifticonDetailActivity : AppCompatActivity() {
 
     @Inject
     lateinit var authManager: AuthManager
-    private val biometricLauncher: ActivityResultLauncher<Intent> =
+    private val usageBiometricLauncher: ActivityResultLauncher<Intent> =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             when (result.resultCode) {
-                Activity.RESULT_OK -> authenticate()
-                else -> authCallback.onAuthError()
+                Activity.RESULT_OK -> usageAuthCallback.onAuthSuccess()
+                else -> usageAuthCallback.onAuthError()
             }
         }
 
-    private val authCallback = object : AuthCallback {
+    private val usageAuthCallback = object : AuthCallback {
         override fun onAuthSuccess() {
             showUseGifticonDialog()
         }
@@ -90,7 +90,32 @@ class GifticonDetailActivity : AppCompatActivity() {
             if (stringId != null) {
                 Toast.makeText(this@GifticonDetailActivity, getString(stringId), Toast.LENGTH_SHORT).show()
             } else {
-                authenticate()
+                usageAuthenticate()
+            }
+        }
+    }
+
+    private val editBiometricLauncher: ActivityResultLauncher<Intent> =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            when (result.resultCode) {
+                Activity.RESULT_OK -> editAuthCallback.onAuthSuccess()
+                else -> editAuthCallback.onAuthError()
+            }
+        }
+
+    private val editAuthCallback = object : AuthCallback {
+        override fun onAuthSuccess() {
+            gotoModifyGifticon(viewModel.gifticon.value?.id)
+        }
+
+        override fun onAuthCancel() {
+        }
+
+        override fun onAuthError(@StringRes stringId: Int?) {
+            if (stringId != null) {
+                Toast.makeText(this@GifticonDetailActivity, getString(stringId), Toast.LENGTH_SHORT).show()
+            } else {
+                usageAuthenticate()
             }
         }
     }
@@ -180,11 +205,11 @@ class GifticonDetailActivity : AppCompatActivity() {
             }
 
             is GifticonDetailEvent.EditButtonClicked -> {
-                gotoModifyGifticon(viewModel.gifticon.value?.id)
+                editAuthenticate()
             }
 
             is GifticonDetailEvent.UseGifticonButtonClicked -> {
-                authenticate()
+                usageAuthenticate()
             }
 
             is GifticonDetailEvent.ShowAllUsedInfoButtonClicked -> {
@@ -253,8 +278,12 @@ class GifticonDetailActivity : AppCompatActivity() {
         }
     }
 
-    private fun authenticate() {
-        authManager.auth(this, biometricLauncher, authCallback)
+    private fun usageAuthenticate() {
+        authManager.auth(this, usageBiometricLauncher, usageAuthCallback)
+    }
+
+    private fun editAuthenticate() {
+        authManager.auth(this, editBiometricLauncher, editAuthCallback)
     }
 
     private fun showOriginGifticonDialog(path: String) {

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailActivity.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailActivity.kt
@@ -232,6 +232,14 @@ class GifticonDetailActivity : AppCompatActivity() {
                 showLargeBarcodeDialog(event.barcode)
             }
 
+            GifticonDetailEvent.InvalidCashCardUsage -> {
+                Toast.makeText(
+                    this,
+                    getString(R.string.gifticon_detail_invalid_cashcard_message),
+                    Toast.LENGTH_SHORT,
+                ).show()
+            }
+
             GifticonDetailEvent.ShareButtonClicked -> {
                 // TODO 공유 기능
             }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailActivity.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailActivity.kt
@@ -19,6 +19,7 @@ import androidx.core.view.isVisible
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.commit
 import androidx.lifecycle.lifecycleScope
+import com.google.android.material.snackbar.Snackbar
 import com.lighthouse.presentation.R
 import com.lighthouse.presentation.databinding.ActivityGifticonDetailBinding
 import com.lighthouse.presentation.extension.isOnScreen
@@ -220,6 +221,7 @@ class GifticonDetailActivity : AppCompatActivity() {
                 if (::useGifticonDialog.isInitialized && useGifticonDialog.isAdded) {
                     useGifticonDialog.dismiss()
                 }
+                showCancelUsageSnackBar()
             }
 
             is GifticonDetailEvent.ShowOriginalImage -> {
@@ -293,6 +295,19 @@ class GifticonDetailActivity : AppCompatActivity() {
                 putParcelable(Extras.KEY_ORIGIN_IMAGE, uri)
             }
         }.show(supportFragmentManager)
+    }
+
+    private fun showCancelUsageSnackBar() {
+        Snackbar.make(
+            binding.root,
+            getString(R.string.gifticon_detail_after_usage_message),
+            5000,
+        ).apply {
+            setAction(R.string.gifticon_detail_used_mode_button_text) {
+                viewModel.cancelUsage()
+                dismiss()
+            }
+        }.show()
     }
 
     private fun showLargeBarcodeDialog(barcode: String) {

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailEvent.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailEvent.kt
@@ -9,4 +9,5 @@ sealed class GifticonDetailEvent {
     object EditButtonClicked : GifticonDetailEvent()
     object UseGifticonButtonClicked : GifticonDetailEvent()
     object UseGifticonComplete : GifticonDetailEvent()
+    object InvalidCashCardUsage : GifticonDetailEvent()
 }

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailViewModel.kt
@@ -209,9 +209,7 @@ class GifticonDetailViewModel @Inject constructor(
             }
 
             GifticonDetailMode.USED -> {
-                viewModelScope.launch {
-                    unUseGifticonUseCase(gifticonId)
-                }
+                cancelUsage()
             }
         }
     }
@@ -260,6 +258,12 @@ class GifticonDetailViewModel @Inject constructor(
 
     fun updateLocationPermission(isLocationPermission: Boolean) {
         hasLocationPermission.value = isLocationPermission
+    }
+
+    fun cancelUsage() {
+        viewModelScope.launch {
+            unUseGifticonUseCase(gifticonId)
+        }
     }
 
     private fun event(event: GifticonDetailEvent) {

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailViewModel.kt
@@ -10,7 +10,6 @@ import com.lighthouse.domain.usecase.UnUseGifticonUseCase
 import com.lighthouse.domain.usecase.UseCashCardGifticonUseCase
 import com.lighthouse.domain.usecase.UseGifticonUseCase
 import com.lighthouse.presentation.R
-import com.lighthouse.presentation.extension.toConcurrency
 import com.lighthouse.presentation.extension.toDayOfMonth
 import com.lighthouse.presentation.extension.toMonth
 import com.lighthouse.presentation.extension.toYear
@@ -108,11 +107,21 @@ class GifticonDetailViewModel @Inject constructor(
     private val _historyUiModel = MutableStateFlow<List<HistoryUiModel>>(emptyList())
     val historyUiModel = _historyUiModel.asStateFlow()
 
+    val balanceOriginUIText: StateFlow<UIText> = gifticon.transform {
+        if (it == null) return@transform
+        emit(
+            it.balance?.let { balance ->
+                UIText.NumberFormatString(balance, R.string.all_cash_unit)
+            } ?: UIText.Empty,
+        )
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), UIText.Empty)
+
     val balanceUIText: StateFlow<UIText> = gifticon.transform {
         if (it == null) return@transform
         emit(
-            it.balance?.let { balance -> UIText.StringResource(R.string.all_balance_label, balance.toConcurrency()) }
-                ?: UIText.Empty,
+            it.balance?.let { balance ->
+                UIText.NumberFormatString(balance, R.string.all_balance_label)
+            } ?: UIText.Empty,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), UIText.Empty)
 

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailViewModel.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/GifticonDetailViewModel.kt
@@ -222,6 +222,8 @@ class GifticonDetailViewModel @Inject constructor(
                 if (amountToBeUsed.value > 0) { // 0원 이상인 경우만 사용 처리
                     useCashCardGifticonUseCase(gifticonId, amountToBeUsed.value, hasLocationPermission.value)
                     editBalance(0)
+                } else {
+                    event(GifticonDetailEvent.InvalidCashCardUsage)
                 }
                 event(GifticonDetailEvent.UseGifticonComplete)
             } else {

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/dialog/UseGifticonDialog.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/detailgifticon/dialog/UseGifticonDialog.kt
@@ -69,8 +69,10 @@ class UseGifticonDialog : BottomSheetDialogFragment(R.layout.dialog_use_gifticon
     }
 
     private fun initBottomSheetDialog(view: View) {
-        val bottomSheetBehavior = BottomSheetBehavior.from(view.parent as View)
-        bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
+        BottomSheetBehavior.from(view.parent as View).apply {
+            state = BottomSheetBehavior.STATE_EXPANDED
+            skipCollapsed = true
+        }
         binding.layoutContainer.minHeight = (screenHeight * 0.9).toInt()
     }
 

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/security/pin/PinDialog.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/security/pin/PinDialog.kt
@@ -45,8 +45,8 @@ class PinDialog(private val authCallback: AuthCallback) : BottomSheetDialogFragm
                     PinSettingType.CONFIRM -> binding.tvPinDescription.text = getString(R.string.pin_input_description)
                     PinSettingType.WRONG -> binding.tvPinDescription.text = getString(R.string.pin_wrong_description)
                     PinSettingType.COMPLETE -> {
+                        delay(500L)
                         authCallback.onAuthSuccess()
-                        delay(1000L)
                         dismiss()
                     }
                     else -> {}

--- a/presentation/src/main/java/com/lighthouse/presentation/ui/security/pin/PinDialog.kt
+++ b/presentation/src/main/java/com/lighthouse/presentation/ui/security/pin/PinDialog.kt
@@ -49,6 +49,7 @@ class PinDialog(private val authCallback: AuthCallback) : BottomSheetDialogFragm
                         authCallback.onAuthSuccess()
                         dismiss()
                     }
+
                     else -> {}
                 }
             }
@@ -56,8 +57,10 @@ class PinDialog(private val authCallback: AuthCallback) : BottomSheetDialogFragm
     }
 
     private fun initBottomSheetDialog(view: View) {
-        val bottomSheetBehavior = BottomSheetBehavior.from(view.parent as View)
-        bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
+        BottomSheetBehavior.from(view.parent as View).apply {
+            state = BottomSheetBehavior.STATE_EXPANDED
+            skipCollapsed = true
+        }
         binding.clPin.minHeight = (screenHeight * 0.9).toInt()
     }
 

--- a/presentation/src/main/res/layout/fragment_cash_card_gifticon_info.xml
+++ b/presentation/src/main/res/layout/fragment_cash_card_gifticon_info.xml
@@ -81,7 +81,7 @@
         <androidx.constraintlayout.widget.Group
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:constraint_referenced_ids="tv_expire_at_label,tv_expire_at,tv_balance_label,ctf_balance"
+            app:constraint_referenced_ids="tv_expire_at_label,tv_expire_at,tv_balance_label,tv_balance"
             app:isVisible="@{!vm.gifticon.used}"
             tools:visibility="visible" />
 
@@ -119,18 +119,15 @@
             app:layout_constraintStart_toStartOf="@id/gl_center_horizontal"
             app:layout_constraintTop_toTopOf="@id/tv_expire_at_label" />
 
-        <com.lighthouse.presentation.ui.common.ConcurrencyTextField
-            android:id="@+id/ctf_balance"
+        <TextView
+            android:id="@+id/tv_balance"
+            style="@style/Theme.BEEP.TextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="4dp"
-            android:minWidth="100dp"
-            android:paddingStart="0dp"
-            android:paddingEnd="16dp"
-            app:editable="false"
             app:layout_constraintStart_toStartOf="@id/gl_center_horizontal"
             app:layout_constraintTop_toBottomOf="@id/tv_balance_label"
-            app:value="@{vm.gifticon.balance}"
+            app:setUIText="@{vm.balanceOriginUIText}"
             tools:text="3,620원" />
 
         <androidx.constraintlayout.widget.Group

--- a/presentation/src/main/res/layout/fragment_setting.xml
+++ b/presentation/src/main/res/layout/fragment_setting.xml
@@ -9,37 +9,33 @@
             type="com.lighthouse.presentation.ui.setting.SettingViewModel" />
     </data>
 
-    <androidx.core.widget.NestedScrollView
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="match_parent">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/ab_setting"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="?attr/colorPrimarySurface"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
-            <com.google.android.material.appbar.AppBarLayout
-                android:id="@+id/ab_setting"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:background="?attr/colorPrimarySurface"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
-
-                <com.google.android.material.appbar.MaterialToolbar
-                    android:id="@+id/tb_setting"
-                    android:layout_width="match_parent"
-                    android:layout_height="?attr/actionBarSize"
-                    app:title="@string/main_menu_setting"
-                    app:titleCentered="true" />
-            </com.google.android.material.appbar.AppBarLayout>
-
-            <androidx.fragment.app.FragmentContainerView
-                android:id="@+id/fcv_setting"
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/tb_setting"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                app:layout_constraintTop_toBottomOf="@id/ab_setting" />
+                android:layout_height="?attr/actionBarSize"
+                app:title="@string/main_menu_setting"
+                app:titleCentered="true" />
+        </com.google.android.material.appbar.AppBarLayout>
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </androidx.core.widget.NestedScrollView>
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/fcv_setting"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/ab_setting" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -312,4 +312,5 @@
     <string name="gifticon_detail_scroll_down_chip_unused">사용하기</string>
     <string name="gifticon_detail_scroll_down_chip_used">사용취소</string>
     <string name="gifticon_detail_scroll_down_chip_edit">수정완료</string>
+    <string name="gifticon_detail_after_usage_message">기프티콘을 사용했습니다</string>
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -313,4 +313,5 @@
     <string name="gifticon_detail_scroll_down_chip_used">사용취소</string>
     <string name="gifticon_detail_scroll_down_chip_edit">수정완료</string>
     <string name="gifticon_detail_after_usage_message">기프티콘을 사용했습니다</string>
+    <string name="gifticon_detail_invalid_cashcard_message">사용할 금액이 지정되지 않아 사용 처리되지 않았습니다</string>
 </resources>


### PR DESCRIPTION
resolved: #290 

## 작업 내용

- 사용 다이얼로그, PIN 다이얼로그의 collapse 과정 스킵
- `사용한 기프티콘 확인` 화면이 이상하게 표시되던 버그 수정
- 기프티콘 수정 시 보안 인증 수행
- 기타 소소한 스타일 수정

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정

## 동작 화면

### 수정 시 보안 인증

![이미지](https://user-images.githubusercontent.com/44221447/224505398-372e25bd-5957-430a-9d8a-4dc0aa64eb9a.gif)

### collapse 과정 스킵. 튕기는 제스처에서 바로 창을 닫음

![화면 기록 2023-03-12 오전 3 22 27](https://user-images.githubusercontent.com/44221447/224505400-5100abbb-e206-425c-ba99-71b03d730efb.gif)

### `사용한 기프티콘 확인` 화면 레이아웃 버그 수정

![스크린샷 2023-03-12 오전 3 23 33](https://user-images.githubusercontent.com/44221447/224505401-91d4e83d-38bb-45b3-9c07-7722dd618375.png)
